### PR TITLE
Fix error created by vk-bootstrap update, and apply .clang-format formatting.

### DIFF
--- a/src/Core/AssetModule/IEAspect.hpp
+++ b/src/Core/AssetModule/IEAspect.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
 class IEAsset;
 
@@ -17,7 +17,7 @@ class IEAsset;
  */
 class IEAspect {
 public:
-	virtual ~IEAspect() = default;
+    virtual ~IEAspect() = default;
 
-	std::vector<std::weak_ptr<IEAsset>> associatedAssets{};  // A vector of assets that this aspect belongs to
+    std::vector<std::weak_ptr<IEAsset>> associatedAssets{};  // A vector of assets that this aspect belongs to
 };

--- a/src/Core/AssetModule/IEAsset.cpp
+++ b/src/Core/AssetModule/IEAsset.cpp
@@ -1,6 +1,6 @@
 #include "IEAsset.hpp"
 
 void IEAsset::addAspect(IEAspect *aspect) {
-	aspects.emplace_back(aspect);
-	aspect->associatedAssets.push_back(weak_from_this());
+    aspects.emplace_back(aspect);
+    aspect->associatedAssets.push_back(weak_from_this());
 }

--- a/src/Core/AssetModule/IEAsset.hpp
+++ b/src/Core/AssetModule/IEAsset.hpp
@@ -2,22 +2,25 @@
 
 #include <string>
 #include <vector>
+
 #define GLM_FORCE_RADIANS
-#include <glm/glm.hpp>
-#include <algorithm>
-#include <memory>
+
 #include "IEAspect.hpp"
+
+#include <algorithm>
+#include <glm/glm.hpp>
+#include <memory>
 
 class IEAsset : public std::enable_shared_from_this<IEAsset> {
 public:
-	// Things that are shared among all aspects of an asset
-	glm::vec3 position{0.0, 0.0, 0.0};
-	glm::vec3 rotation{0.0, 0.0, 0.0};
-	glm::vec3 scale{1.0, 1.0, 1.0};
-	std::string filename{};
-	std::vector<std::shared_ptr<IEAspect>> aspects{};
+    // Things that are shared among all aspects of an asset
+    glm::vec3                              position{0.0, 0.0, 0.0};
+    glm::vec3                              rotation{0.0, 0.0, 0.0};
+    glm::vec3                              scale{1.0, 1.0, 1.0};
+    std::string                            filename{};
+    std::vector<std::shared_ptr<IEAspect>> aspects{};
 
-	void addAspect(IEAspect *aspect);
+    void addAspect(IEAspect *aspect);
 };
 
 /*

--- a/src/Core/FileSystemModule/IEDirectory.cpp
+++ b/src/Core/FileSystemModule/IEDirectory.cpp
@@ -5,27 +5,24 @@ IEDirectory::IEDirectory(const std::string &initialPath) {
 }
 
 void IEDirectory::createDirectory() const {
-    for (size_t i = 0; i < path.size(); ++i) {
-        if (path[i] == '/') {
-            std::filesystem::create_directory(path.substr(0, i));
-        }
-    }
+    for (size_t i = 0; i < path.size(); ++i)
+        if (path[i] == '/') std::filesystem::create_directory(path.substr(0, i));
     std::filesystem::create_directory(path);
 }
 
 std::vector<IEDirectory *> IEDirectory::allDirectories() {
-    std::vector<IEDirectory*> allSubDirectories{subDirectories};
-    for (IEDirectory* subDirectory : subDirectories) {
-        std::vector<IEDirectory*> theseSubDirectories{subDirectory->allDirectories()};
+    std::vector<IEDirectory *> allSubDirectories{subDirectories};
+    for (IEDirectory *subDirectory : subDirectories) {
+        std::vector<IEDirectory *> theseSubDirectories{subDirectory->allDirectories()};
         allSubDirectories.insert(allSubDirectories.end(), theseSubDirectories.begin(), theseSubDirectories.end());
     }
     return allSubDirectories;
 }
 
 std::vector<IEFile *> IEDirectory::allFiles() {
-    std::vector<IEFile*> allFiles{files};
-    for (IEDirectory* subDirectory : subDirectories) {
-        std::vector<IEFile*> theseFiles{subDirectory->allFiles()};
+    std::vector<IEFile *> allFiles{files};
+    for (IEDirectory *subDirectory : subDirectories) {
+        std::vector<IEFile *> theseFiles{subDirectory->allFiles()};
         allFiles.insert(allFiles.end(), theseFiles.begin(), theseFiles.end());
     }
     return allFiles;

--- a/src/Core/FileSystemModule/IEDirectory.hpp
+++ b/src/Core/FileSystemModule/IEDirectory.hpp
@@ -15,18 +15,18 @@ public:
      * @brief Creates a new IEDirectory with a path
      * @param initialPath
      */
-    explicit IEDirectory(const std::string& initialPath);
+    explicit IEDirectory(const std::string &initialPath);
 
-    std::vector<IEDirectory*> subDirectories{};
-    std::vector<IEFile*> files{};
-    std::string path{};
-    bool exists{};
+    std::vector<IEDirectory *> subDirectories{};
+    std::vector<IEFile *>      files{};
+    std::string                path{};
+    bool                       exists{};
 
     void createDirectory() const;
 
-    std::vector<IEDirectory*> allDirectories();
+    std::vector<IEDirectory *> allDirectories();
 
-    std::vector<IEFile*> allFiles();
+    std::vector<IEFile *> allFiles();
 
     void create();
 

--- a/src/Core/FileSystemModule/IEFile.cpp
+++ b/src/Core/FileSystemModule/IEFile.cpp
@@ -11,22 +11,15 @@ std::string IEFile::getDirectory() const {
 
 void IEFile::createDirectory() const {
     std::string thisDirectory{getDirectory()};
-    for (size_t i = 0; i < thisDirectory.size(); ++i) {
-        if (thisDirectory[i] == '/') {
-            std::filesystem::create_directory(thisDirectory.substr(0, i));
-        }
-    }
+    for (size_t i = 0; i < thisDirectory.size(); ++i)
+        if (thisDirectory[i] == '/') std::filesystem::create_directory(thisDirectory.substr(0, i));
     std::filesystem::create_directory(thisDirectory);
 }
 
 bool IEFile::open() {
-    if (file.is_open()) {
-        return true;
-    }
+    if (file.is_open()) return true;
     file.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::ate | std::ios_base::binary);
-    if (!file.is_open()) {
-        file.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary);
-    }
+    if (!file.is_open()) file.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary);
     if (!file.is_open()) {
         createDirectory();
         file.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary);
@@ -39,16 +32,13 @@ bool IEFile::open() {
 }
 
 void IEFile::close() {
-    if (!file.is_open()) {
-        return;
-    }
+    if (!file.is_open()) return;
     file.close();
 }
 
 std::string IEFile::read(size_t numBytes, std::streamsize startPosition) {
-    if (startPosition == -1) {  // If no starting position
+    if (startPosition == -1)           // If no starting position
         startPosition = file.tellg();  // Start here
-    }
     // Go to start position
     file.seekg(startPosition);
 
@@ -68,9 +58,8 @@ void IEFile::insert(const std::string &data, std::streamsize startPosition) {
         // Attempt to insert from beyond the length of the file!
         return;
     }
-    if (startPosition == -1) {  // If no starting position
+    if (startPosition == -1)           // If no starting position
         startPosition = file.tellg();  // Start here
-    }
 
     // Read data that is about to be overwritten
     std::string bytes = read((size_t) (length - startPosition), startPosition);
@@ -84,16 +73,15 @@ void IEFile::insert(const std::string &data, std::streamsize startPosition) {
 
     // Update file length
     auto dataSize = static_cast<std::streamsize>(startPosition + data.size());
-    length = static_cast<std::streamsize>(dataSize + bytes.size());
+    length        = static_cast<std::streamsize>(dataSize + bytes.size());
 
     // Go to end of new data
     file.seekg(dataSize);
 }
 
 void IEFile::overwrite(const std::string &data, std::streamsize startPosition) {
-    if (startPosition == -1) {  // If no starting position
+    if (startPosition == -1)           // If no starting position
         startPosition = file.tellg();  // Start here
-    }
 
     // Go to starting position
     file.seekg(startPosition);
@@ -107,9 +95,8 @@ void IEFile::overwrite(const std::string &data, std::streamsize startPosition) {
 }
 
 void IEFile::erase(std::streamsize numBytes, std::streamsize startPosition) {
-    if (startPosition == -1) {  // If no starting position
+    if (startPosition == -1)           // If no starting position
         startPosition = file.tellg();  // Start here
-    }
 
     // Go to where file should stop being erased
     file.seekg(startPosition + numBytes);
@@ -126,14 +113,12 @@ void IEFile::erase(std::streamsize numBytes, std::streamsize startPosition) {
 }
 
 std::vector<std::string> IEFile::extensions() const {
-    std::string temporaryPath = path.substr(path.find_last_of('/') + 1);
-    std::vector<std::string> result;
-    std::regex rgx("[.]");
+    std::string                temporaryPath = path.substr(path.find_last_of('/') + 1);
+    std::vector<std::string>   result;
+    std::regex                 rgx("[.]");
     std::sregex_token_iterator iter(temporaryPath.begin(), temporaryPath.end(), rgx, -1);
     std::sregex_token_iterator end;
-    for (++iter; iter != end; ++iter) {
-        result.push_back(*iter);
-    }
+    for (++iter; iter != end; ++iter) result.push_back(*iter);
     return result;
 }
 
@@ -143,7 +128,7 @@ IEFile::~IEFile() {
 
 IEFile &IEFile::operator=(const IEFile &other) {
     // Copy over data from other
-    path = other.path;
+    path   = other.path;
     length = other.length;
 
     // Close this file to avoid memory leaks

--- a/src/Core/FileSystemModule/IEFile.hpp
+++ b/src/Core/FileSystemModule/IEFile.hpp
@@ -1,41 +1,41 @@
 #pragma once
 
-#include <vector>
-#include <string>
 #include <filesystem>
 #include <fstream>
-#include <regex>
 #include <iostream>
+#include <regex>
+#include <string>
+#include <vector>
 
 class IEFile {
 public:
-	IEFile() = default;
+    IEFile() = default;
 
-	explicit IEFile(const std::string &initialPath);
+    explicit IEFile(const std::string &initialPath);
 
-	std::streamsize length{};
-	std::string path{};
-	std::fstream file{};
+    std::streamsize length{};
+    std::string     path{};
+    std::fstream    file{};
 
-	std::string getDirectory() const;
+    std::string getDirectory() const;
 
-	void createDirectory() const;
+    void createDirectory() const;
 
-	bool open();
+    bool open();
 
-	void close();
+    void close();
 
-	virtual std::string read(size_t numBytes, std::streamsize startPosition = -1);
+    virtual std::string read(size_t numBytes, std::streamsize startPosition = -1);
 
-	void insert(const std::string &data, std::streamsize startPosition = -1);
+    void insert(const std::string &data, std::streamsize startPosition = -1);
 
-	void overwrite(const std::string &data, std::streamsize startPosition = -1);
+    void overwrite(const std::string &data, std::streamsize startPosition = -1);
 
-	void erase(std::streamsize numBytes, std::streamsize startPosition = -1);
+    void erase(std::streamsize numBytes, std::streamsize startPosition = -1);
 
-	std::vector<std::string> extensions() const;
+    std::vector<std::string> extensions() const;
 
-	~IEFile();
+    ~IEFile();
 
-	IEFile &operator=(const IEFile &other);
+    IEFile &operator=(const IEFile &other);
 };

--- a/src/Core/FileSystemModule/IEFileSystem.cpp
+++ b/src/Core/FileSystemModule/IEFileSystem.cpp
@@ -9,19 +9,17 @@ IEFileSystem::IEFileSystem(const IEDirectory &initialBaseDirectory) {
 }
 
 template<typename... Args>
-std::string IEFileSystem::composePath(IEPathName format, const Args &... args) {
+std::string IEFileSystem::composePath(IEPathName format, const Args &...args) {
     std::vector<std::string> arguments = {args...};
-    std::string pathName{};
-    for (const std::string& argument : arguments) {
-        pathName += "/" + argument;
-    }
+    std::string              pathName{};
+    for (const std::string &argument : arguments) pathName += "/" + argument;
     if (format & IE_FILE_BIT) {
         size_t beginFileName = pathName.find_last_of('/');
-        pathName = pathName.substr(0, beginFileName) + '.' + pathName.substr(beginFileName + 1);
+        pathName             = pathName.substr(0, beginFileName) + '.' + pathName.substr(beginFileName + 1);
     }
     if (format & IE_HIDDEN_BIT) {
         size_t beginFileName = pathName.find_last_of('/');
-        pathName = pathName.substr(0, beginFileName + 1) + '.' + pathName.substr(beginFileName + 1);
+        pathName             = pathName.substr(0, beginFileName + 1) + '.' + pathName.substr(beginFileName + 1);
     }
     return pathName.substr(1);
 }

--- a/src/Core/FileSystemModule/IEFileSystem.hpp
+++ b/src/Core/FileSystemModule/IEFileSystem.hpp
@@ -1,69 +1,81 @@
-#include "IEFile.hpp"
 #include "IEDirectory.hpp"
+#include "IEFile.hpp"
 
-#include <vector>
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 #define ILLUMINATION_ENGINE_ASSET_FILE_EXTENSION "iea"
 
 enum IEPathName {
-    IE_FILE_BIT = 0x1,
-    IE_DIRECTORY_BIT = 0x10,
-    IE_HIDDEN_BIT = 0x100,
-    IE_VISIBLE_FILE = IE_FILE_BIT,
+    IE_FILE_BIT          = 0x1,
+    IE_DIRECTORY_BIT     = 0x10,
+    IE_HIDDEN_BIT        = 0x100,
+    IE_VISIBLE_FILE      = IE_FILE_BIT,
     IE_VISIBLE_DIRECTORY = IE_DIRECTORY_BIT,
-    IE_HIDDEN_FILE = IE_FILE_BIT | IE_HIDDEN_BIT,
-    IE_HIDDEN_DIRECTORY = IE_DIRECTORY_BIT | IE_HIDDEN_BIT
+    IE_HIDDEN_FILE       = IE_FILE_BIT | IE_HIDDEN_BIT,
+    IE_HIDDEN_DIRECTORY  = IE_DIRECTORY_BIT | IE_HIDDEN_BIT
 };
 
 class IEFileSystem {
 private:
-    std::unordered_map<std::string, IEFile> files{};
-    std::unordered_map<std::string, IEDirectory> directories{};
+    std::unordered_map<std::string, IEFile>        files{};
+    std::unordered_map<std::string, IEDirectory>   directories{};
     std::vector<std::variant<IEFile, IEDirectory>> trash{};
-    IEDirectory baseDirectory{};
+    IEDirectory                                    baseDirectory{};
 
 public:
-    explicit IEFileSystem(const std::string& initialAssetDirectory);
+    explicit IEFileSystem(const std::string &initialAssetDirectory);
 
-    explicit IEFileSystem(const IEDirectory& initialBaseDirectory);
+    explicit IEFileSystem(const IEDirectory &initialBaseDirectory);
 
-    template<typename... Args> static std::string composePath(IEPathName format, const Args&... args);
+    template<typename... Args>
+    static std::string composePath(IEPathName format, const Args &...args);
 
-    IEFile* getAssetFile(const std::string& assetName) {
-        IEFile* file = &files[assetName];
+    IEFile *getAssetFile(const std::string &assetName) {
+        IEFile *file = &files[assetName];
         if (file->path.empty()) {
-            *file = IEFile{composePath(IE_VISIBLE_FILE, baseDirectory.path, assetName, assetName, ILLUMINATION_ENGINE_ASSET_FILE_EXTENSION)};
+            *file = IEFile{composePath(
+              IE_VISIBLE_FILE,
+              baseDirectory.path,
+              assetName,
+              assetName,
+              ILLUMINATION_ENGINE_ASSET_FILE_EXTENSION
+            )};
         }
         return file;
     }
 
-    IEFile* getFile(const std::string& filePath, bool isCompletePath=true) {
-        IEFile* file = &files[filePath];
+    IEFile *getFile(const std::string &filePath, bool isCompletePath = true) {
+        IEFile *file = &files[filePath];
         if (file->path.empty()) {
 
             // Do this if the path is complete
             if (!isCompletePath) {
-                *file = IEFile{composePath(IE_VISIBLE_FILE, baseDirectory.path, filePath, filePath, ILLUMINATION_ENGINE_ASSET_FILE_EXTENSION)};
-            }
-            else  {
+                *file = IEFile{composePath(
+                  IE_VISIBLE_FILE,
+                  baseDirectory.path,
+                  filePath,
+                  filePath,
+                  ILLUMINATION_ENGINE_ASSET_FILE_EXTENSION
+                )};
+            } else {
                 *file = IEFile{filePath};
             }
         }
         return file;
     }
 
-    template <typename... Args> auto getAssetDirectory(Args&&... args) -> decltype(getDirectory(std::forward<Args>(args)...)) {
+    template<typename... Args>
+    auto getAssetDirectory(Args &&...args) -> decltype(getDirectory(std::forward<Args>(args)...)) {
         return getDirectory(std::forward<Args>(args)...);
     }
 
-    IEDirectory* getDirectory(const std::string& assetName) {
-        IEDirectory* directory = &directories[assetName];
-        if (directory->path.empty()) {
+    IEDirectory *getDirectory(const std::string &assetName) {
+        IEDirectory *directory = &directories[assetName];
+        if (directory->path.empty())
             *directory = IEDirectory{composePath(IE_DIRECTORY_BIT, baseDirectory.path, assetName)};
-        }
         return directory;
     }
 };

--- a/src/Core/IEWindowUser.hpp
+++ b/src/Core/IEWindowUser.hpp
@@ -10,6 +10,6 @@ class IERenderEngine;
  */
 class IEWindowUser {
 public:
-	std::weak_ptr<IERenderEngine> renderEngine;
-	void *IEKeyboard;
+    std::weak_ptr<IERenderEngine> renderEngine;
+    void                         *IEKeyboard;
 };

--- a/src/Core/LogModule/IELogger.cpp
+++ b/src/Core/LogModule/IELogger.cpp
@@ -1,8 +1,7 @@
 #include "IELogger.hpp"
 
-#include <include/spdlog/spdlog.h>
 #include <include/spdlog/sinks/basic_file_sink.h>
-
+#include <include/spdlog/spdlog.h>
 
 IELogger::IELogger(const std::string &name, const std::string &path) {
     logger = spdlog::basic_logger_mt(name, path, true);

--- a/src/Core/LogModule/IELogger.hpp
+++ b/src/Core/LogModule/IELogger.hpp
@@ -1,31 +1,30 @@
 #pragma once
 
 #include <include/spdlog/logger.h>
-
-#include <string>
 #include <memory>
+#include <string>
 
-//Illumination Engine replacements for spdlog log levels.
-#define ILLUMINATION_ENGINE_LOG_LEVEL_TRACE spdlog::level::trace
-#define ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG spdlog::level::debug
-#define ILLUMINATION_ENGINE_LOG_LEVEL_INFO spdlog::level::info
-#define ILLUMINATION_ENGINE_LOG_LEVEL_WARN spdlog::level::warn
-#define ILLUMINATION_ENGINE_LOG_LEVEL_ERROR spdlog::level::err
-#define ILLUMINATION_ENGINE_LOG_LEVEL_CRITICAL spdlog::level::critical
-#define ILLUMINATION_ENGINE_LOG_LEVEL_OFF spdlog::level::off
-#define ILLUMINATION_ENGINE_LOG_LEVEL_MAX spdlog::level::n_levels
-#define ILLUMINATION_ENGINE_LOG_LEVEL_0 ILLUMINATION_ENGINE_LOG_LEVEL_TRACE
-#define ILLUMINATION_ENGINE_LOG_LEVEL_1 ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG
-#define ILLUMINATION_ENGINE_LOG_LEVEL_2 ILLUMINATION_ENGINE_LOG_LEVEL_INFO
-#define ILLUMINATION_ENGINE_LOG_LEVEL_3 ILLUMINATION_ENGINE_LOG_LEVEL_WARN
-#define ILLUMINATION_ENGINE_LOG_LEVEL_4 ILLUMINATION_ENGINE_LOG_LEVEL_ERROR
-#define ILLUMINATION_ENGINE_LOG_LEVEL_5 ILLUMINATION_ENGINE_LOG_LEVEL_CRITICAL
-#define ILLUMINATION_ENGINE_LOG_LEVEL_6 ILLUMINATION_ENGINE_LOG_LEVEL_OFF
-#define ILLUMINATION_ENGINE_LOG_LEVEL_SEVERITY_LOW ILLUMINATION_ENGINE_LOG_LEVEL_3
+// Illumination Engine replacements for spdlog log levels.
+#define ILLUMINATION_ENGINE_LOG_LEVEL_TRACE           spdlog::level::trace
+#define ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG           spdlog::level::debug
+#define ILLUMINATION_ENGINE_LOG_LEVEL_INFO            spdlog::level::info
+#define ILLUMINATION_ENGINE_LOG_LEVEL_WARN            spdlog::level::warn
+#define ILLUMINATION_ENGINE_LOG_LEVEL_ERROR           spdlog::level::err
+#define ILLUMINATION_ENGINE_LOG_LEVEL_CRITICAL        spdlog::level::critical
+#define ILLUMINATION_ENGINE_LOG_LEVEL_OFF             spdlog::level::off
+#define ILLUMINATION_ENGINE_LOG_LEVEL_MAX             spdlog::level::n_levels
+#define ILLUMINATION_ENGINE_LOG_LEVEL_0               ILLUMINATION_ENGINE_LOG_LEVEL_TRACE
+#define ILLUMINATION_ENGINE_LOG_LEVEL_1               ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG
+#define ILLUMINATION_ENGINE_LOG_LEVEL_2               ILLUMINATION_ENGINE_LOG_LEVEL_INFO
+#define ILLUMINATION_ENGINE_LOG_LEVEL_3               ILLUMINATION_ENGINE_LOG_LEVEL_WARN
+#define ILLUMINATION_ENGINE_LOG_LEVEL_4               ILLUMINATION_ENGINE_LOG_LEVEL_ERROR
+#define ILLUMINATION_ENGINE_LOG_LEVEL_5               ILLUMINATION_ENGINE_LOG_LEVEL_CRITICAL
+#define ILLUMINATION_ENGINE_LOG_LEVEL_6               ILLUMINATION_ENGINE_LOG_LEVEL_OFF
+#define ILLUMINATION_ENGINE_LOG_LEVEL_SEVERITY_LOW    ILLUMINATION_ENGINE_LOG_LEVEL_3
 #define ILLUMINATION_ENGINE_LOG_LEVEL_SEVERITY_MEDIUM ILLUMINATION_ENGINE_LOG_LEVEL_4
-#define ILLUMINATION_ENGINE_LOG_LEVEL_SEVERITY_HIGH ILLUMINATION_ENGINE_LOG_LEVEL_5
+#define ILLUMINATION_ENGINE_LOG_LEVEL_SEVERITY_HIGH   ILLUMINATION_ENGINE_LOG_LEVEL_5
 
-#define ILLUMINATION_ENGINE_DEFAULT_LOGGER_NAME "Illumination Engine Default Logger"
+#define ILLUMINATION_ENGINE_DEFAULT_LOGGER_NAME  "Illumination Engine Default Logger"
 #define ILLUMINATION_ENGINE_DEFAULT_LOG_FILENAME "IlluminationEngine.log"
 
 /**
@@ -34,12 +33,12 @@
  */
 class IELogger {
 public:
-	IELogger(const std::string &name, const std::string &path);
+    IELogger(const std::string &name, const std::string &path);
 
-	explicit IELogger();
+    explicit IELogger();
 
-	void log(spdlog::level::level_enum level, const std::string &msg) const;
+    void log(spdlog::level::level_enum level, const std::string &msg) const;
 
 private:
-	std::shared_ptr<spdlog::logger> logger;
+    std::shared_ptr<spdlog::logger> logger;
 };

--- a/src/GraphicsModule/Buffer/IEBuffer.cpp
+++ b/src/GraphicsModule/Buffer/IEBuffer.cpp
@@ -4,401 +4,430 @@
 /* Include dependencies within this module. */
 #include "IERenderEngine.hpp"
 
-
 void IEBuffer::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_uploadToRAM = &IEBuffer::_openglUploadToRAM;
-		_uploadToVRAM = &IEBuffer::_openglUploadToVRAM;
-		_uploadToVRAM_vector = &IEBuffer::_openglUploadToVRAM_vector;
-		_uploadToVRAM_void = &IEBuffer::_openglUploadToVRAM_void;
-		_update_vector = &IEBuffer::_openglUpdate_vector;
-		_update_void = &IEBuffer::_openglUpdate_void;
-		_unloadFromVRAM = &IEBuffer::_openglUnloadFromVRAM;
-		_destroy = &IEBuffer::_openglDestroy;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_uploadToRAM = &IEBuffer::_vulkanUploadToRAM;
-		_uploadToVRAM = &IEBuffer::_vulkanUploadToVRAM;
-		_uploadToVRAM_vector = &IEBuffer::_vulkanUploadToVRAM_vector;
-		_uploadToVRAM_void = &IEBuffer::_vulkanUploadToVRAM_void;
-		_update_vector = &IEBuffer::_vulkanUpdate_vector;
-		_update_void = &IEBuffer::_vulkanUpdate_void;
-		_unloadFromVRAM = &IEBuffer::_vulkanUnloadFromVRAM;
-		_destroy = &IEBuffer::_vulkanDestroy;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _uploadToRAM         = &IEBuffer::_openglUploadToRAM;
+        _uploadToVRAM        = &IEBuffer::_openglUploadToVRAM;
+        _uploadToVRAM_vector = &IEBuffer::_openglUploadToVRAM_vector;
+        _uploadToVRAM_void   = &IEBuffer::_openglUploadToVRAM_void;
+        _update_vector       = &IEBuffer::_openglUpdate_vector;
+        _update_void         = &IEBuffer::_openglUpdate_void;
+        _unloadFromVRAM      = &IEBuffer::_openglUnloadFromVRAM;
+        _destroy             = &IEBuffer::_openglDestroy;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _uploadToRAM         = &IEBuffer::_vulkanUploadToRAM;
+        _uploadToVRAM        = &IEBuffer::_vulkanUploadToVRAM;
+        _uploadToVRAM_vector = &IEBuffer::_vulkanUploadToVRAM_vector;
+        _uploadToVRAM_void   = &IEBuffer::_vulkanUploadToVRAM_void;
+        _update_vector       = &IEBuffer::_vulkanUpdate_vector;
+        _update_void         = &IEBuffer::_vulkanUpdate_void;
+        _unloadFromVRAM      = &IEBuffer::_vulkanUnloadFromVRAM;
+        _destroy             = &IEBuffer::_vulkanDestroy;
+    }
 }
 
-
 void IEBuffer::uploadToRAM(void *pData, size_t dataSize) {
-	data = std::vector<char>{(char *) pData, (char *) ((uint64_t) pData + dataSize)};
-	if (!data.empty()) {
-		status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_RAM | status);
-	}
+    data = std::vector<char>{(char *) pData, (char *) ((uint64_t) pData + dataSize)};
+    if (!data.empty()) status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_RAM | status);
 }
 
 void IEBuffer::uploadToRAM(const std::vector<char> &dataVector) {
-	data = dataVector;
-	status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_RAM | status);
+    data   = dataVector;
+    status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_RAM | status);
 }
-
 
 std::function<void(IEBuffer &)> IEBuffer::_uploadToRAM;
 
 void IEBuffer::uploadToRAM() {
-	_uploadToRAM(*this);
+    _uploadToRAM(*this);
 }
 
 void IEBuffer::_openglUploadToRAM() {
-	/**@todo Load from VRAM to RAM somehow.*/
+    /**@todo Load from VRAM to RAM somehow.*/
 }
 
 void IEBuffer::_vulkanUploadToRAM() {
-	void *internalBufferData;
-	vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
-	memcpy(data.data(), internalBufferData, size);
-	vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
+    void *internalBufferData;
+    vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
+    memcpy(data.data(), internalBufferData, size);
+    vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
 }
-
 
 void IEBuffer::toImage(const std::shared_ptr<IEImage> &image) {
-	VkBufferImageCopy region{};
-	region.imageSubresource.aspectMask = image->aspect & (VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT);
-	region.imageSubresource.layerCount = 1;
-	region.imageExtent = {image->width, image->height, 1};
-	if (image->layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
-		VkImageLayout oldLayout = image->layout;
-		image->transitionLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-		linkedRenderEngine->graphicsCommandPool->index(0)->recordCopyBufferToImage(shared_from_this(), image, {region});
-		if (oldLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
-			image->transitionLayout(oldLayout);
-		}
-	} else {
-		linkedRenderEngine->graphicsCommandPool->index(0)->recordCopyBufferToImage(shared_from_this(), image, {region});
-	}
+    VkBufferImageCopy region{};
+    region.imageSubresource.aspectMask = image->aspect & (VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT);
+    region.imageSubresource.layerCount = 1;
+    region.imageExtent                 = {image->width, image->height, 1};
+    if (image->layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
+        VkImageLayout oldLayout = image->layout;
+        image->transitionLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+        linkedRenderEngine->graphicsCommandPool->index(0)
+          ->recordCopyBufferToImage(shared_from_this(), image, {region});
+        if (oldLayout != VK_IMAGE_LAYOUT_UNDEFINED) image->transitionLayout(oldLayout);
+    } else {
+        linkedRenderEngine->graphicsCommandPool->index(0)
+          ->recordCopyBufferToImage(shared_from_this(), image, {region});
+    }
 }
-
 
 IEBuffer::~IEBuffer() {
-	destroy();
+    destroy();
 }
-
 
 IEBuffer::IEBuffer(IERenderEngine *engineLink, IEBuffer::CreateInfo *createInfo) {
-	create(engineLink, createInfo);
+    create(engineLink, createInfo);
 }
 
-IEBuffer::IEBuffer(IERenderEngine *engineLink, size_t bufferSize, VkBufferUsageFlags usageFlags, VmaMemoryUsage memoryUsage, GLenum bufferType) {
-	create(engineLink, bufferSize, usageFlags, memoryUsage, bufferType);
+IEBuffer::IEBuffer(
+  IERenderEngine    *engineLink,
+  size_t             bufferSize,
+  VkBufferUsageFlags usageFlags,
+  VmaMemoryUsage     memoryUsage,
+  GLenum             bufferType
+) {
+    create(engineLink, bufferSize, usageFlags, memoryUsage, bufferType);
 }
 
 void IEBuffer::create(IERenderEngine *engineLink, IEBuffer::CreateInfo *createInfo) {
-	if (status == IE_BUFFER_STATUS_NONE) {
-		linkedRenderEngine = engineLink;
-		size = createInfo->size;
-		usage = createInfo->usage;
-		allocationUsage = createInfo->allocationUsage;
-		type = createInfo->type;
-	}
-	status = IE_BUFFER_STATUS_UNLOADED;
+    if (status == IE_BUFFER_STATUS_NONE) {
+        linkedRenderEngine = engineLink;
+        size               = createInfo->size;
+        usage              = createInfo->usage;
+        allocationUsage    = createInfo->allocationUsage;
+        type               = createInfo->type;
+    }
+    status = IE_BUFFER_STATUS_UNLOADED;
 }
 
-void IEBuffer::create(IERenderEngine *engineLink, size_t bufferSize, VkBufferUsageFlags usageFlags, VmaMemoryUsage memoryUsage, GLenum bufferType) {
-	if (status == IE_BUFFER_STATUS_NONE) {
-		linkedRenderEngine = engineLink;
-		size = bufferSize;
-		usage = usageFlags;
-		allocationUsage = memoryUsage;
-		type = bufferType;
-	}
-	status = IE_BUFFER_STATUS_UNLOADED;
+void IEBuffer::create(
+  IERenderEngine    *engineLink,
+  size_t             bufferSize,
+  VkBufferUsageFlags usageFlags,
+  VmaMemoryUsage     memoryUsage,
+  GLenum             bufferType
+) {
+    if (status == IE_BUFFER_STATUS_NONE) {
+        linkedRenderEngine = engineLink;
+        size               = bufferSize;
+        usage              = usageFlags;
+        allocationUsage    = memoryUsage;
+        type               = bufferType;
+    }
+    status = IE_BUFFER_STATUS_UNLOADED;
 }
-
 
 std::function<void(IEBuffer &)> IEBuffer::_uploadToVRAM = nullptr;
 
 void IEBuffer::uploadToVRAM() {
-	_uploadToVRAM(*this);
+    _uploadToVRAM(*this);
 }
 
 void IEBuffer::_openglUploadToVRAM() {
-	if ((status & IE_BUFFER_STATUS_DATA_IN_RAM) == 0) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to load buffer with no contents in RAM to VRAM.");
-	}
-	if (!(status & IE_BUFFER_STATUS_DATA_IN_VRAM)) {  // Not in VRAM
-		glGenBuffers(1, &id);  // Put it in VRAM
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {
-		glBindBuffer(type, id);
-		glBufferData(type, (GLsizeiptr) size, data.data(), GL_STATIC_DRAW);
-		glBindBuffer(type, 0);
-	}
+    if ((status & IE_BUFFER_STATUS_DATA_IN_RAM) == 0) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Attempt to load buffer with no contents in RAM to VRAM."
+        );
+    }
+    if (!(status & IE_BUFFER_STATUS_DATA_IN_VRAM))  // Not in VRAM
+        glGenBuffers(1, &id);                       // Put it in VRAM
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {
+        glBindBuffer(type, id);
+        glBufferData(type, (GLsizeiptr) size, data.data(), GL_STATIC_DRAW);
+        glBindBuffer(type, 0);
+    }
 }
 
 void IEBuffer::_vulkanUploadToVRAM() {
-	if ((status & IE_BUFFER_STATUS_DATA_IN_RAM) == 0) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to load buffer with no contents in RAM to VRAM.");
-	}
-	if ((status & IE_BUFFER_STATUS_DATA_IN_VRAM) == 0) {
-		// Create the VkBuffer because it does not yet exist.
-		VmaAllocationCreateInfo allocationCreateInfo{
-				.usage=allocationUsage,
-		};
-		VkBufferCreateInfo bufferCreateInfo{
-				.sType=VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-				.size=size,
-				.usage=usage,
-		};
+    if ((status & IE_BUFFER_STATUS_DATA_IN_RAM) == 0) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Attempt to load buffer with no contents in RAM to VRAM."
+        );
+    }
+    if ((status & IE_BUFFER_STATUS_DATA_IN_VRAM) == 0) {
+        // Create the VkBuffer because it does not yet exist.
+        VmaAllocationCreateInfo allocationCreateInfo{
+          .usage = allocationUsage,
+        };
+        VkBufferCreateInfo bufferCreateInfo{
+          .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+          .size  = size,
+          .usage = usage,
+        };
 
-		// If usage requests device address, then prepare allocation for using device address
-		if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
-			allocationCreateInfo.requiredFlags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-		}
+        // If usage requests device address, then prepare allocation for using device address
+        if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U)
+            allocationCreateInfo.requiredFlags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
 
-		// Create buffer and update status
-		vmaCreateBuffer(linkedRenderEngine->allocator, &bufferCreateInfo, &allocationCreateInfo, &buffer, &allocation, nullptr);
-		status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_VRAM | status);
+        // Create buffer and update status
+        vmaCreateBuffer(
+          linkedRenderEngine->allocator,
+          &bufferCreateInfo,
+          &allocationCreateInfo,
+          &buffer,
+          &allocation,
+          nullptr
+        );
+        status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_VRAM | status);
 
-		// Get the buffer device address if requested
-		if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
-			VkBufferDeviceAddressInfoKHR bufferDeviceAddressInfo{VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
-			bufferDeviceAddressInfo.buffer = buffer;
-			deviceAddress = linkedRenderEngine->vkGetBufferDeviceAddressKHR(linkedRenderEngine->device.device, &bufferDeviceAddressInfo);
-		}
-	}
+        // Get the buffer device address if requested
+        if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
+            VkBufferDeviceAddressInfoKHR bufferDeviceAddressInfo{VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
+            bufferDeviceAddressInfo.buffer = buffer;
+            deviceAddress                  = linkedRenderEngine->vkGetBufferDeviceAddressKHR(
+              linkedRenderEngine->device.device,
+              &bufferDeviceAddressInfo
+            );
+        }
+    }
 
-	// Upload data in RAM to VRAM
-	void *internalBufferData;
-	vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
-	memcpy(internalBufferData, data.data(), data.size());
-	vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
+    // Upload data in RAM to VRAM
+    void *internalBufferData;
+    vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
+    memcpy(internalBufferData, data.data(), data.size());
+    vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
 }
-
 
 std::function<void(IEBuffer &, const std::vector<char> &)> IEBuffer::_uploadToVRAM_vector = nullptr;
 
 void IEBuffer::uploadToVRAM(const std::vector<char> &data) {
-	_uploadToVRAM_vector(*this, data);
+    _uploadToVRAM_vector(*this, data);
 }
 
 void IEBuffer::_openglUploadToVRAM_vector(const std::vector<char> &data) {
-	if (!(status & IE_BUFFER_STATUS_DATA_IN_VRAM)) {  // Not in VRAM
-		glGenBuffers(1, &id);  // Put it in VRAM
-		size = data.size();
-		status = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
-	}
+    if (!(status & IE_BUFFER_STATUS_DATA_IN_VRAM)) {  // Not in VRAM
+        glGenBuffers(1, &id);                         // Put it in VRAM
+        size   = data.size();
+        status = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
+    }
 
-	// Upload data
-	glBindBuffer(type, id);
-	glBufferData(type, (GLsizeiptr) data.size() * (GLsizeiptr) sizeof(data[0]), data.data(), GL_STATIC_DRAW);
-	glBindBuffer(type, 0);
+    // Upload data
+    glBindBuffer(type, id);
+    glBufferData(type, (GLsizeiptr) data.size() * (GLsizeiptr) sizeof(data[0]), data.data(), GL_STATIC_DRAW);
+    glBindBuffer(type, 0);
 }
 
 void IEBuffer::_vulkanUploadToVRAM_vector(const std::vector<char> &data) {
-	if ((status & IE_BUFFER_STATUS_DATA_IN_VRAM) == 0) {
-		// Create the VkBuffer because it does not yet exist.
-		VmaAllocationCreateInfo allocationCreateInfo{
-				.usage=allocationUsage,
-		};
-		VkBufferCreateInfo bufferCreateInfo{
-				.sType=VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-				.size=size,
-				.usage=usage,
-		};
+    if ((status & IE_BUFFER_STATUS_DATA_IN_VRAM) == 0) {
+        // Create the VkBuffer because it does not yet exist.
+        VmaAllocationCreateInfo allocationCreateInfo{
+          .usage = allocationUsage,
+        };
+        VkBufferCreateInfo bufferCreateInfo{
+          .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+          .size  = size,
+          .usage = usage,
+        };
 
-		// If usage requests device address, then prepare allocation for using device address
-		if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
-			allocationCreateInfo.requiredFlags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-		}
+        // If usage requests device address, then prepare allocation for using device address
+        if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U)
+            allocationCreateInfo.requiredFlags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
 
-		// Create buffer and update status
-		vmaCreateBuffer(linkedRenderEngine->allocator, &bufferCreateInfo, &allocationCreateInfo, &buffer, &allocation, nullptr);
-		status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_VRAM | status);
+        // Create buffer and update status
+        vmaCreateBuffer(
+          linkedRenderEngine->allocator,
+          &bufferCreateInfo,
+          &allocationCreateInfo,
+          &buffer,
+          &allocation,
+          nullptr
+        );
+        status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_VRAM | status);
 
-		// Get the buffer device address if requested
-		if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
-			VkBufferDeviceAddressInfoKHR bufferDeviceAddressInfo{VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
-			bufferDeviceAddressInfo.buffer = buffer;
-			deviceAddress = linkedRenderEngine->vkGetBufferDeviceAddressKHR(linkedRenderEngine->device.device, &bufferDeviceAddressInfo);
-		}
-		status = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
-	}
+        // Get the buffer device address if requested
+        if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
+            VkBufferDeviceAddressInfoKHR bufferDeviceAddressInfo{VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
+            bufferDeviceAddressInfo.buffer = buffer;
+            deviceAddress                  = linkedRenderEngine->vkGetBufferDeviceAddressKHR(
+              linkedRenderEngine->device.device,
+              &bufferDeviceAddressInfo
+            );
+        }
+        status = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
+    }
 
-	// Upload data in RAM to VRAM
-	void *internalBufferData;
-	vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
-	memcpy(internalBufferData, data.data(), data.size());
-	vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
+    // Upload data in RAM to VRAM
+    void *internalBufferData;
+    vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
+    memcpy(internalBufferData, data.data(), data.size());
+    vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
 }
-
 
 std::function<void(IEBuffer &, void *, size_t)> IEBuffer::_uploadToVRAM_void = nullptr;
 
 void IEBuffer::uploadToVRAM(void *data, size_t size) {
-	_uploadToVRAM_void(*this, data, size);
+    _uploadToVRAM_void(*this, data, size);
 }
 
 void IEBuffer::_openglUploadToVRAM_void(void *data, size_t size) {
-	if (!(status & IE_BUFFER_STATUS_DATA_IN_VRAM)) {  // Not in VRAM?
-		glGenBuffers(1, &id);  // Put it in VRAM
-		this->size = size;
-		status = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
-	}
+    if (!(status & IE_BUFFER_STATUS_DATA_IN_VRAM)) {  // Not in VRAM?
+        glGenBuffers(1, &id);                         // Put it in VRAM
+        this->size = size;
+        status     = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
+    }
 
-	// Upload data
-	glBindBuffer(type, id);
-	glBufferData(type, (GLsizeiptr) size, data, GL_STATIC_DRAW);
-	glBindBuffer(type, 0);
+    // Upload data
+    glBindBuffer(type, id);
+    glBufferData(type, (GLsizeiptr) size, data, GL_STATIC_DRAW);
+    glBindBuffer(type, 0);
 }
 
 void IEBuffer::_vulkanUploadToVRAM_void(void *data, size_t size) {
-	if ((status & IE_BUFFER_STATUS_DATA_IN_VRAM) == 0) {
-		// Create the VkBuffer because it does not yet exist.
-		VmaAllocationCreateInfo allocationCreateInfo{
-				.usage=allocationUsage,
-		};
-		VkBufferCreateInfo bufferCreateInfo{
-				.sType=VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-				.size=size,
-				.usage=usage,
-		};
+    if ((status & IE_BUFFER_STATUS_DATA_IN_VRAM) == 0) {
+        // Create the VkBuffer because it does not yet exist.
+        VmaAllocationCreateInfo allocationCreateInfo{
+          .usage = allocationUsage,
+        };
+        VkBufferCreateInfo bufferCreateInfo{
+          .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+          .size  = size,
+          .usage = usage,
+        };
 
-		// If usage requests device address, then prepare allocation for using device address
-		if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
-			allocationCreateInfo.requiredFlags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-		}
+        // If usage requests device address, then prepare allocation for using device address
+        if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U)
+            allocationCreateInfo.requiredFlags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
 
-		// Create buffer and update status
-		vmaCreateBuffer(linkedRenderEngine->allocator, &bufferCreateInfo, &allocationCreateInfo, &buffer, &allocation, nullptr);
-		status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_VRAM | status);
+        // Create buffer and update status
+        vmaCreateBuffer(
+          linkedRenderEngine->allocator,
+          &bufferCreateInfo,
+          &allocationCreateInfo,
+          &buffer,
+          &allocation,
+          nullptr
+        );
+        status = static_cast<IEBufferStatus>(IE_BUFFER_STATUS_DATA_IN_VRAM | status);
 
-		// Get the buffer device address if requested
-		if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
-			VkBufferDeviceAddressInfoKHR bufferDeviceAddressInfo{VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
-			bufferDeviceAddressInfo.buffer = buffer;
-			deviceAddress = linkedRenderEngine->vkGetBufferDeviceAddressKHR(linkedRenderEngine->device.device, &bufferDeviceAddressInfo);
-		}
+        // Get the buffer device address if requested
+        if ((usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) != 0U) {
+            VkBufferDeviceAddressInfoKHR bufferDeviceAddressInfo{VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
+            bufferDeviceAddressInfo.buffer = buffer;
+            deviceAddress                  = linkedRenderEngine->vkGetBufferDeviceAddressKHR(
+              linkedRenderEngine->device.device,
+              &bufferDeviceAddressInfo
+            );
+        }
 
-		this->size = size;
-		status = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
+        this->size = size;
+        status     = static_cast<IEBufferStatus>(status | IE_BUFFER_STATUS_DATA_IN_VRAM);
+    }
 
-	}
-
-	// Upload data in RAM to VRAM
-	void *internalBufferData;
-	vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
-	memcpy(internalBufferData, data, size);
-	vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
+    // Upload data in RAM to VRAM
+    void *internalBufferData;
+    vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
+    memcpy(internalBufferData, data, size);
+    vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
 }
-
 
 std::function<void(IEBuffer &, const std::vector<char> &)> IEBuffer::_update_vector = nullptr;
 
 void IEBuffer::update(const std::vector<char> &data) {
-	_update_vector(*this, data);
+    _update_vector(*this, data);
 }
 
 void IEBuffer::_openglUpdate_vector(const std::vector<char> &data) {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		glBindBuffer(type, id);
-		glBufferData(type, (GLsizeiptr) data.size() * (GLsizeiptr) sizeof(data[0]), data.data(), GL_STATIC_DRAW);
-		glBindBuffer(type, 0);
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
-		this->data = data;
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        glBindBuffer(type, id);
+        glBufferData(type, (GLsizeiptr) data.size() * (GLsizeiptr) sizeof(data[0]), data.data(), GL_STATIC_DRAW);
+        glBindBuffer(type, 0);
+    }
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM)  // In RAM?
+        this->data = data;
 }
 
 void IEBuffer::_vulkanUpdate_vector(const std::vector<char> &data) {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		// Upload data in RAM to VRAM
-		void *internalBufferData;
-		vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
-		memcpy(internalBufferData, data.data(), data.size());
-		vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
-		this->data = data;
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        // Upload data in RAM to VRAM
+        void *internalBufferData;
+        vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
+        memcpy(internalBufferData, data.data(), data.size());
+        vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
+    }
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM)  // In RAM?
+        this->data = data;
 }
-
 
 std::function<void(IEBuffer &, void *, size_t)> IEBuffer::_update_void = nullptr;
 
 void IEBuffer::update(void *data, size_t size) {
-	_update_void(*this, data, size);
+    _update_void(*this, data, size);
 }
 
 void IEBuffer::_openglUpdate_void(void *data, size_t size) {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		glBindBuffer(type, id);
-		glBufferData(type, (GLsizeiptr) size, data, GL_STATIC_DRAW);
-		glBindBuffer(type, 0);
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
-		this->data = std::vector<char>{(char *) data, (char *) ((size_t) data + size)};
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        glBindBuffer(type, id);
+        glBufferData(type, (GLsizeiptr) size, data, GL_STATIC_DRAW);
+        glBindBuffer(type, 0);
+    }
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM)  // In RAM?
+        this->data = std::vector<char>{(char *) data, (char *) ((size_t) data + size)};
 }
 
 void IEBuffer::_vulkanUpdate_void(void *data, size_t size) {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		// Upload data in RAM to VRAM
-		void *internalBufferData;
-		vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
-		memcpy(internalBufferData, data, size);
-		vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
-		this->data = std::vector<char>{(char *) data, (char *) ((size_t) data + size)};
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        // Upload data in RAM to VRAM
+        void *internalBufferData;
+        vmaMapMemory(linkedRenderEngine->allocator, allocation, &internalBufferData);
+        memcpy(internalBufferData, data, size);
+        vmaUnmapMemory(linkedRenderEngine->allocator, allocation);
+    }
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM)  // In RAM?
+        this->data = std::vector<char>{(char *) data, (char *) ((size_t) data + size)};
 }
-
 
 std::function<void(IEBuffer &)> IEBuffer::_unloadFromVRAM = nullptr;
 
 void IEBuffer::unloadFromVRAM() {
-	_unloadFromVRAM(*this);
+    _unloadFromVRAM(*this);
 }
 
 void IEBuffer::_openglUnloadFromVRAM() {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		glDeleteBuffers(1, &id);
-		status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM);  // Not in VRAM
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        glDeleteBuffers(1, &id);
+        status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM);  // Not in VRAM
+    }
 }
 
 void IEBuffer::_vulkanUnloadFromVRAM() {
-	vmaDestroyBuffer(linkedRenderEngine->allocator, buffer, allocation);
-	status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM);
+    vmaDestroyBuffer(linkedRenderEngine->allocator, buffer, allocation);
+    status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM);
 }
-
 
 std::function<void(IEBuffer &)> IEBuffer::_destroy = nullptr;
 
 void IEBuffer::destroy() {
-	invalidateDependents();
-	_destroy(*this);
+    invalidateDependents();
+    _destroy(*this);
 }
 
 void IEBuffer::_openglDestroy() {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		glDeleteBuffers(1, &id);
-		status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM | IE_BUFFER_STATUS_QUEUED_VRAM);
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
-		data.clear();
-		status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_RAM & ~IE_BUFFER_STATUS_QUEUED_VRAM | IE_BUFFER_STATUS_QUEUED_RAM);
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        glDeleteBuffers(1, &id);
+        status =
+          static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM | IE_BUFFER_STATUS_QUEUED_VRAM);
+    }
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
+        data.clear();
+        status = static_cast<IEBufferStatus>(
+          status & ~IE_BUFFER_STATUS_DATA_IN_RAM & ~IE_BUFFER_STATUS_QUEUED_VRAM | IE_BUFFER_STATUS_QUEUED_RAM
+        );
+    }
 }
 
 void IEBuffer::_vulkanDestroy() {
-	if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
-		vmaDestroyBuffer(linkedRenderEngine->allocator, buffer, allocation);
-		status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM | IE_BUFFER_STATUS_QUEUED_VRAM);
-	}
-	if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
-		data.clear();
-		status = static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_RAM & ~IE_BUFFER_STATUS_QUEUED_VRAM | IE_BUFFER_STATUS_QUEUED_RAM);
-	}
+    if (status & IE_BUFFER_STATUS_DATA_IN_VRAM) {  // In VRAM?
+        vmaDestroyBuffer(linkedRenderEngine->allocator, buffer, allocation);
+        status =
+          static_cast<IEBufferStatus>(status & ~IE_BUFFER_STATUS_DATA_IN_VRAM | IE_BUFFER_STATUS_QUEUED_VRAM);
+    }
+    if (status & IE_BUFFER_STATUS_DATA_IN_RAM) {  // In RAM?
+        data.clear();
+        status = static_cast<IEBufferStatus>(
+          status & ~IE_BUFFER_STATUS_DATA_IN_RAM & ~IE_BUFFER_STATUS_QUEUED_VRAM | IE_BUFFER_STATUS_QUEUED_RAM
+        );
+    }
 }
-
 
 IEBuffer::IEBuffer() = default;

--- a/src/GraphicsModule/Buffer/IEBuffer.hpp
+++ b/src/GraphicsModule/Buffer/IEBuffer.hpp
@@ -14,144 +14,155 @@ class IERenderEngine;
 #include <include/vk_mem_alloc.h>
 
 #define GLEW_IMPLEMENTATION
-#include <include/GL/glew.h>
 
+#include <include/GL/glew.h>
 #include <vulkan/vulkan.h>
 
 // System dependencies
-#include <vector>
 #include <cstdint>
 #include <functional>
-
+#include <vector>
 
 class IEBuffer : public IEDependency, public std::enable_shared_from_this<IEBuffer> {
 public:
-	struct CreateInfo {
-		size_t size{};
-		VkBufferUsageFlags usage{};
-		VmaMemoryUsage allocationUsage{};
+    struct CreateInfo {
+        size_t             size{};
+        VkBufferUsageFlags usage{};
+        VmaMemoryUsage     allocationUsage{};
 
-		GLenum type{};
-	};
+        GLenum type{};
+    };
 
-	using IEBufferStatus = enum IEBufferStatus {
-		IE_BUFFER_STATUS_NONE = 0x0,
-		IE_BUFFER_STATUS_UNLOADED = 0x1,
-		IE_BUFFER_STATUS_QUEUED_RAM = 0x2,
-		IE_BUFFER_STATUS_DATA_IN_RAM = 0x4,
-		IE_BUFFER_STATUS_QUEUED_VRAM = 0x8,
-		IE_BUFFER_STATUS_DATA_IN_VRAM = 0x10
-	};
+    using IEBufferStatus = enum IEBufferStatus {
+        IE_BUFFER_STATUS_NONE         = 0x0,
+        IE_BUFFER_STATUS_UNLOADED     = 0x1,
+        IE_BUFFER_STATUS_QUEUED_RAM   = 0x2,
+        IE_BUFFER_STATUS_DATA_IN_RAM  = 0x4,
+        IE_BUFFER_STATUS_QUEUED_VRAM  = 0x8,
+        IE_BUFFER_STATUS_DATA_IN_VRAM = 0x10
+    };
 
-	std::vector<char> data{};
-	VkBuffer buffer{};
-	VkDeviceAddress deviceAddress{};
-	size_t size{};
-	VkBufferUsageFlags usage{};
-	VmaMemoryUsage allocationUsage{};
-	std::vector<std::function<void()>> deletionQueue{};
-	IEBufferStatus status{IE_BUFFER_STATUS_NONE};
-	GLuint id{};
-	GLenum type{};
+    std::vector<char>                  data{};
+    VkBuffer                           buffer{};
+    VkDeviceAddress                    deviceAddress{};
+    size_t                             size{};
+    VkBufferUsageFlags                 usage{};
+    VmaMemoryUsage                     allocationUsage{};
+    std::vector<std::function<void()>> deletionQueue{};
+    IEBufferStatus                     status{IE_BUFFER_STATUS_NONE};
+    GLuint                             id{};
+    GLenum                             type{};
 
 private:
-	static std::function<void(IEBuffer &)> _uploadToRAM;
+    static std::function<void(IEBuffer &)> _uploadToRAM;
 
-	static std::function<void(IEBuffer &)> _uploadToVRAM;
-	static std::function<void(IEBuffer &, const std::vector<char> &)> _uploadToVRAM_vector;
-	static std::function<void(IEBuffer &, void *, size_t)> _uploadToVRAM_void;
+    static std::function<void(IEBuffer &)>                            _uploadToVRAM;
+    static std::function<void(IEBuffer &, const std::vector<char> &)> _uploadToVRAM_vector;
+    static std::function<void(IEBuffer &, void *, size_t)>            _uploadToVRAM_void;
 
-	static std::function<void(IEBuffer &, const std::vector<char> &)> _update_vector;
-	static std::function<void(IEBuffer &, void *, size_t)> _update_void;
+    static std::function<void(IEBuffer &, const std::vector<char> &)> _update_vector;
+    static std::function<void(IEBuffer &, void *, size_t)>            _update_void;
 
-	static std::function<void(IEBuffer &)> _unloadFromVRAM;
+    static std::function<void(IEBuffer &)> _unloadFromVRAM;
 
-	static std::function<void(IEBuffer &)> _destroy;
+    static std::function<void(IEBuffer &)> _destroy;
 
 protected:
-	virtual void _openglUploadToRAM();
+    virtual void _openglUploadToRAM();
 
-	virtual void _vulkanUploadToRAM();
-
-
-	virtual void _openglUploadToVRAM();
-
-	virtual void _vulkanUploadToVRAM();
-
-	virtual void _openglUploadToVRAM_vector(const std::vector<char> &);
-
-	virtual void _vulkanUploadToVRAM_vector(const std::vector<char> &);
-
-	virtual void _openglUploadToVRAM_void(void *, size_t);
-
-	virtual void _vulkanUploadToVRAM_void(void *, size_t);
+    virtual void _vulkanUploadToRAM();
 
 
-	virtual void _openglUpdate_vector(const std::vector<char> &);
+    virtual void _openglUploadToVRAM();
 
-	virtual void _vulkanUpdate_vector(const std::vector<char> &);
+    virtual void _vulkanUploadToVRAM();
 
-	virtual void _openglUpdate_void(void *, size_t);
+    virtual void _openglUploadToVRAM_vector(const std::vector<char> &);
 
-	virtual void _vulkanUpdate_void(void *, size_t);
+    virtual void _vulkanUploadToVRAM_vector(const std::vector<char> &);
+
+    virtual void _openglUploadToVRAM_void(void *, size_t);
+
+    virtual void _vulkanUploadToVRAM_void(void *, size_t);
 
 
-	virtual void _openglUnloadFromVRAM();
+    virtual void _openglUpdate_vector(const std::vector<char> &);
 
-	virtual void _vulkanUnloadFromVRAM();
+    virtual void _vulkanUpdate_vector(const std::vector<char> &);
+
+    virtual void _openglUpdate_void(void *, size_t);
+
+    virtual void _vulkanUpdate_void(void *, size_t);
 
 
-	virtual void _openglDestroy();
+    virtual void _openglUnloadFromVRAM();
 
-	virtual void _vulkanDestroy();
+    virtual void _vulkanUnloadFromVRAM();
+
+
+    virtual void _openglDestroy();
+
+    virtual void _vulkanDestroy();
 
 public:
-	IEBuffer();
+    IEBuffer();
 
-	IEBuffer(IERenderEngine *, IEBuffer::CreateInfo *);
+    IEBuffer(IERenderEngine *, IEBuffer::CreateInfo *);
 
-	IEBuffer(IERenderEngine *engineLink, size_t bufferSize, VkBufferUsageFlags usageFlags, VmaMemoryUsage memoryUsage, GLenum bufferType);
-
-
-	static void setAPI(const IEAPI &API);
-
-
-	void create(IERenderEngine *engineLink, IEBuffer::CreateInfo *createInfo);
-
-	void create(IERenderEngine *engineLink, size_t bufferSize, VkBufferUsageFlags usageFlags, VmaMemoryUsage memoryUsage, GLenum bufferType);
+    IEBuffer(
+      IERenderEngine    *engineLink,
+      size_t             bufferSize,
+      VkBufferUsageFlags usageFlags,
+      VmaMemoryUsage     memoryUsage,
+      GLenum             bufferType
+    );
 
 
-	void toImage(const std::shared_ptr<IEImage> &image);
+    static void setAPI(const IEAPI &API);
 
 
-	void uploadToRAM();
+    void create(IERenderEngine *engineLink, IEBuffer::CreateInfo *createInfo);
 
-	void uploadToRAM(const std::vector<char> &);
-
-	void uploadToRAM(void *, size_t);
-
-
-	virtual void uploadToVRAM();
-
-	void uploadToVRAM(const std::vector<char> &);
-
-	void uploadToVRAM(void *, size_t);
+    void create(
+      IERenderEngine    *engineLink,
+      size_t             bufferSize,
+      VkBufferUsageFlags usageFlags,
+      VmaMemoryUsage     memoryUsage,
+      GLenum             bufferType
+    );
 
 
-	void update(const std::vector<char> &);
-
-	void update(void *, size_t);
+    void toImage(const std::shared_ptr<IEImage> &image);
 
 
-	void unloadFromVRAM();
+    void uploadToRAM();
+
+    void uploadToRAM(const std::vector<char> &);
+
+    void uploadToRAM(void *, size_t);
 
 
-	void destroy();
+    virtual void uploadToVRAM();
+
+    void uploadToVRAM(const std::vector<char> &);
+
+    void uploadToVRAM(void *, size_t);
 
 
-	~IEBuffer() override;
+    void update(const std::vector<char> &);
+
+    void update(void *, size_t);
+
+
+    void unloadFromVRAM();
+
+
+    void destroy();
+
+
+    ~IEBuffer() override;
 
 protected:
-	IERenderEngine *linkedRenderEngine{};
-	VmaAllocation allocation{};
+    IERenderEngine *linkedRenderEngine{};
+    VmaAllocation   allocation{};
 };

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IEBufferMemoryBarrier.cpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IEBufferMemoryBarrier.cpp
@@ -1,38 +1,37 @@
-#include <vulkan/vulkan.h>
 #include "IEBufferMemoryBarrier.hpp"
 
+#include <vulkan/vulkan.h>
+
 std::vector<std::shared_ptr<IEBuffer>> IEBufferMemoryBarrier::getBuffers() const {
-	return {buffer};
+    return {buffer};
 }
 
 std::vector<std::shared_ptr<IEDependency>> IEBufferMemoryBarrier::getDependencies() const {
-	return {buffer};
+    return {buffer};
 }
 
 IEBufferMemoryBarrier::operator VkBufferMemoryBarrier() const {
-	return {
-			.sType=VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
-			.pNext=pNext,
-			.srcAccessMask=srcAccessMask,
-			.dstAccessMask=dstAccessMask,
-			.srcQueueFamilyIndex=srcQueueFamilyIndex,
-			.dstQueueFamilyIndex=dstQueueFamilyIndex,
-			.buffer=buffer->buffer,
-			.offset=offset,
-			.size=size
-	};
+    return {
+      .sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+      .pNext               = pNext,
+      .srcAccessMask       = srcAccessMask,
+      .dstAccessMask       = dstAccessMask,
+      .srcQueueFamilyIndex = srcQueueFamilyIndex,
+      .dstQueueFamilyIndex = dstQueueFamilyIndex,
+      .buffer              = buffer->buffer,
+      .offset              = offset,
+      .size                = size};
 }
 
 IEBufferMemoryBarrier::operator VkBufferMemoryBarrier2() const {
-	return {
-			.sType=VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2,
-			.pNext=pNext,
-			.srcAccessMask=srcAccessMask,
-			.dstAccessMask=dstAccessMask,
-			.srcQueueFamilyIndex=srcQueueFamilyIndex,
-			.dstQueueFamilyIndex=dstQueueFamilyIndex,
-			.buffer=buffer->buffer,
-			.offset=offset,
-			.size=size
-	};
+    return {
+      .sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2,
+      .pNext               = pNext,
+      .srcAccessMask       = srcAccessMask,
+      .dstAccessMask       = dstAccessMask,
+      .srcQueueFamilyIndex = srcQueueFamilyIndex,
+      .dstQueueFamilyIndex = dstQueueFamilyIndex,
+      .buffer              = buffer->buffer,
+      .offset              = offset,
+      .size                = size};
 }

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IEBufferMemoryBarrier.hpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IEBufferMemoryBarrier.hpp
@@ -1,25 +1,26 @@
 #pragma once
 
-#include <vulkan/vulkan.h>
-#include <memory>
 #include "Buffer/IEBuffer.hpp"
+
+#include <memory>
+#include <vulkan/vulkan.h>
 
 class IEBufferMemoryBarrier {
 public:
-	const void *pNext;
-	VkAccessFlags srcAccessMask;
-	VkAccessFlags dstAccessMask;
-	uint32_t srcQueueFamilyIndex;
-	uint32_t dstQueueFamilyIndex;
-	std::shared_ptr<IEBuffer> buffer;
-	VkDeviceSize offset;
-	VkDeviceSize size;
+    const void               *pNext;
+    VkAccessFlags             srcAccessMask;
+    VkAccessFlags             dstAccessMask;
+    uint32_t                  srcQueueFamilyIndex;
+    uint32_t                  dstQueueFamilyIndex;
+    std::shared_ptr<IEBuffer> buffer;
+    VkDeviceSize              offset;
+    VkDeviceSize              size;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEBuffer>> getBuffers() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEBuffer>> getBuffers() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
 
-	explicit operator VkBufferMemoryBarrier() const;
+    explicit operator VkBufferMemoryBarrier() const;
 
-	explicit operator VkBufferMemoryBarrier2() const;
+    explicit operator VkBufferMemoryBarrier2() const;
 };

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IECopyBufferToImageInfo.cpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IECopyBufferToImageInfo.cpp
@@ -1,25 +1,25 @@
 #include "IECopyBufferToImageInfo.hpp"
+
 #include <vector>
 
 std::vector<std::shared_ptr<IEBuffer>> IECopyBufferToImageInfo::getBuffers() const {
-	return {srcBuffer};
+    return {srcBuffer};
 }
 
 std::vector<std::shared_ptr<IEImage>> IECopyBufferToImageInfo::getImages() const {
-	return {dstImage};
+    return {dstImage};
 }
 
 std::vector<std::shared_ptr<IEDependency>> IECopyBufferToImageInfo::getDependencies() const {
-	return {srcBuffer, dstImage};
+    return {srcBuffer, dstImage};
 }
 
 IECopyBufferToImageInfo::operator VkCopyBufferToImageInfo2() const {
-	return {
-			.sType=VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2,
-			.pNext=pNext,
-			.srcBuffer=srcBuffer->buffer,
-			.dstImage=dstImage->image,
-			.regionCount=static_cast<uint32_t>(regions.size()),
-			.pRegions=regions.data()
-	};
+    return {
+      .sType       = VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2,
+      .pNext       = pNext,
+      .srcBuffer   = srcBuffer->buffer,
+      .dstImage    = dstImage->image,
+      .regionCount = static_cast<uint32_t>(regions.size()),
+      .pRegions    = regions.data()};
 }

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IECopyBufferToImageInfo.hpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IECopyBufferToImageInfo.hpp
@@ -1,22 +1,23 @@
 #pragma once
 
-#include <memory>
-#include <vulkan/vulkan.h>
 #include "Buffer/IEBuffer.hpp"
 #include "Image/IEImage.hpp"
 
+#include <memory>
+#include <vulkan/vulkan.h>
+
 class IECopyBufferToImageInfo {
 public:
-	const void *pNext;
-	std::shared_ptr<IEBuffer> srcBuffer;
-	std::shared_ptr<IEImage> dstImage;
-	std::vector<VkBufferImageCopy2> regions;
+    const void                     *pNext;
+    std::shared_ptr<IEBuffer>       srcBuffer;
+    std::shared_ptr<IEImage>        dstImage;
+    std::vector<VkBufferImageCopy2> regions;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEBuffer>> getBuffers() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEBuffer>> getBuffers() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEImage>> getImages() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEImage>> getImages() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
 
-	explicit operator VkCopyBufferToImageInfo2() const;
+    explicit operator VkCopyBufferToImageInfo2() const;
 };

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IEDependencyInfo.cpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IEDependencyInfo.cpp
@@ -1,50 +1,43 @@
 #include "IEDependencyInfo.hpp"
 
 std::vector<std::shared_ptr<IEBuffer>> IEDependencyInfo::getBuffers() const {
-	std::vector<std::shared_ptr<IEBuffer>> buffers{bufferMemoryBarriers.size()};
-	for (const IEBufferMemoryBarrier &bufferBarrier: bufferMemoryBarriers) {
-		buffers.push_back(bufferBarrier.buffer);
-	}
-	return buffers;
+    std::vector<std::shared_ptr<IEBuffer>> buffers{bufferMemoryBarriers.size()};
+    for (const IEBufferMemoryBarrier &bufferBarrier : bufferMemoryBarriers)
+        buffers.push_back(bufferBarrier.buffer);
+    return buffers;
 }
 
 std::vector<std::shared_ptr<IEImage>> IEDependencyInfo::getImages() const {
-	std::vector<std::shared_ptr<IEImage>> images{imageMemoryBarriers.size()};
-	for (const IEImageMemoryBarrier &imageBarrier: imageMemoryBarriers) {
-		images.push_back(imageBarrier.image);
-	}
-	return images;
+    std::vector<std::shared_ptr<IEImage>> images{imageMemoryBarriers.size()};
+    for (const IEImageMemoryBarrier &imageBarrier : imageMemoryBarriers) images.push_back(imageBarrier.image);
+    return images;
 }
 
 std::vector<std::shared_ptr<IEDependency>> IEDependencyInfo::getDependencies() const {
-	std::vector<std::shared_ptr<IEDependency>> dependencies{};
-	for (const IEBufferMemoryBarrier &bufferBarrier: bufferMemoryBarriers) {
-		dependencies.push_back(bufferBarrier.buffer);
-	}
-	for (const IEImageMemoryBarrier &imageBarrier: imageMemoryBarriers) {
-		dependencies.push_back(imageBarrier.image);
-	}
-	return dependencies;
+    std::vector<std::shared_ptr<IEDependency>> dependencies{};
+    for (const IEBufferMemoryBarrier &bufferBarrier : bufferMemoryBarriers)
+        dependencies.push_back(bufferBarrier.buffer);
+    for (const IEImageMemoryBarrier &imageBarrier : imageMemoryBarriers)
+        dependencies.push_back(imageBarrier.image);
+    return dependencies;
 }
 
 IEDependencyInfo::operator VkDependencyInfo() {
-	bufferBarriers.resize(bufferMemoryBarriers.size());
-	for (const IEBufferMemoryBarrier &bufferBarrier: bufferMemoryBarriers) {
-		bufferBarriers.emplace_back((VkBufferMemoryBarrier2) bufferBarrier);
-	}
-	imageBarriers.resize(imageMemoryBarriers.size());
-	for (const IEImageMemoryBarrier &imageBarrier: imageMemoryBarriers) {
-		imageBarriers.emplace_back((VkImageMemoryBarrier2) imageBarrier);
-	}
-	return {
-			.sType=VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
-			.pNext=pNext,
-			.dependencyFlags=dependencyFlags,
-			.memoryBarrierCount=static_cast<uint32_t>(memoryBarriers.size()),
-			.pMemoryBarriers=memoryBarriers.data(),
-			.bufferMemoryBarrierCount=static_cast<uint32_t>(bufferMemoryBarriers.size()),
-			.pBufferMemoryBarriers=bufferBarriers.data(),
-			.imageMemoryBarrierCount=static_cast<uint32_t>(imageMemoryBarriers.size()),
-			.pImageMemoryBarriers=imageBarriers.data(),
-	};
+    bufferBarriers.resize(bufferMemoryBarriers.size());
+    for (const IEBufferMemoryBarrier &bufferBarrier : bufferMemoryBarriers)
+        bufferBarriers.emplace_back((VkBufferMemoryBarrier2) bufferBarrier);
+    imageBarriers.resize(imageMemoryBarriers.size());
+    for (const IEImageMemoryBarrier &imageBarrier : imageMemoryBarriers)
+        imageBarriers.emplace_back((VkImageMemoryBarrier2) imageBarrier);
+    return {
+      .sType                    = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+      .pNext                    = pNext,
+      .dependencyFlags          = dependencyFlags,
+      .memoryBarrierCount       = static_cast<uint32_t>(memoryBarriers.size()),
+      .pMemoryBarriers          = memoryBarriers.data(),
+      .bufferMemoryBarrierCount = static_cast<uint32_t>(bufferMemoryBarriers.size()),
+      .pBufferMemoryBarriers    = bufferBarriers.data(),
+      .imageMemoryBarrierCount  = static_cast<uint32_t>(imageMemoryBarriers.size()),
+      .pImageMemoryBarriers     = imageBarriers.data(),
+    };
 }

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IEDependencyInfo.hpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IEDependencyInfo.hpp
@@ -1,28 +1,29 @@
 #pragma once
 
-#include <vector>
-#include <memory>
-#include <vulkan/vulkan.h>
 #include "IEBufferMemoryBarrier.hpp"
 #include "IEImageMemoryBarrier.hpp"
 
+#include <memory>
+#include <vector>
+#include <vulkan/vulkan.h>
+
 class IEDependencyInfo {
 public:
-	const void *pNext;
-	VkDependencyFlags dependencyFlags;
-	std::vector<VkMemoryBarrier2> memoryBarriers;
-	std::vector<IEBufferMemoryBarrier> bufferMemoryBarriers;
-	std::vector<IEImageMemoryBarrier> imageMemoryBarriers;
+    const void                        *pNext;
+    VkDependencyFlags                  dependencyFlags;
+    std::vector<VkMemoryBarrier2>      memoryBarriers;
+    std::vector<IEBufferMemoryBarrier> bufferMemoryBarriers;
+    std::vector<IEImageMemoryBarrier>  imageMemoryBarriers;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEBuffer>> getBuffers() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEBuffer>> getBuffers() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEImage>> getImages() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEImage>> getImages() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
 
-	explicit operator VkDependencyInfo();
+    explicit operator VkDependencyInfo();
 
 private:
-	std::vector<VkBufferMemoryBarrier2> bufferBarriers{};
-	std::vector<VkImageMemoryBarrier2> imageBarriers{};
+    std::vector<VkBufferMemoryBarrier2> bufferBarriers{};
+    std::vector<VkImageMemoryBarrier2>  imageBarriers{};
 };

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IEImageMemoryBarrier.cpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IEImageMemoryBarrier.cpp
@@ -1,37 +1,35 @@
 #include "IEImageMemoryBarrier.hpp"
 
 std::vector<std::shared_ptr<IEImage>> IEImageMemoryBarrier::getImages() const {
-	return {image};
+    return {image};
 }
 
 std::vector<std::shared_ptr<IEDependency>> IEImageMemoryBarrier::getDependencies() const {
-	return {image};
+    return {image};
 }
 
 IEImageMemoryBarrier::operator VkImageMemoryBarrier() const {
-	return {
-			.sType=VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-			.pNext=pNext,
-			.srcAccessMask=srcAccessMask,
-			.dstAccessMask=dstAccessMask,
-			.newLayout=newLayout,
-			.srcQueueFamilyIndex=srcQueueFamilyIndex,
-			.dstQueueFamilyIndex=dstQueueFamilyIndex,
-			.image=image->image,
-			.subresourceRange=subresourceRange
-	};
+    return {
+      .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+      .pNext               = pNext,
+      .srcAccessMask       = srcAccessMask,
+      .dstAccessMask       = dstAccessMask,
+      .newLayout           = newLayout,
+      .srcQueueFamilyIndex = srcQueueFamilyIndex,
+      .dstQueueFamilyIndex = dstQueueFamilyIndex,
+      .image               = image->image,
+      .subresourceRange    = subresourceRange};
 }
 
 IEImageMemoryBarrier::operator VkImageMemoryBarrier2() const {
-	return {
-			.sType=VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-			.pNext=pNext,
-			.srcAccessMask=srcAccessMask,
-			.dstAccessMask=dstAccessMask,
-			.newLayout=newLayout,
-			.srcQueueFamilyIndex=srcQueueFamilyIndex,
-			.dstQueueFamilyIndex=dstQueueFamilyIndex,
-			.image=image->image,
-			.subresourceRange=subresourceRange
-	};
+    return {
+      .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+      .pNext               = pNext,
+      .srcAccessMask       = srcAccessMask,
+      .dstAccessMask       = dstAccessMask,
+      .newLayout           = newLayout,
+      .srcQueueFamilyIndex = srcQueueFamilyIndex,
+      .dstQueueFamilyIndex = dstQueueFamilyIndex,
+      .image               = image->image,
+      .subresourceRange    = subresourceRange};
 }

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IEImageMemoryBarrier.hpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IEImageMemoryBarrier.hpp
@@ -1,25 +1,26 @@
 #pragma once
 
+#include "Image/IEImage.hpp"
+
 #include <memory>
 #include <vulkan/vulkan.h>
-#include "Image/IEImage.hpp"
 
 class IEImageMemoryBarrier {
 public:
-	const void *pNext;
-	VkAccessFlags srcAccessMask;
-	VkAccessFlags dstAccessMask;
-	VkImageLayout newLayout;
-	uint32_t srcQueueFamilyIndex;
-	uint32_t dstQueueFamilyIndex;
-	std::shared_ptr<IEImage> image;
-	VkImageSubresourceRange subresourceRange;
+    const void              *pNext;
+    VkAccessFlags            srcAccessMask;
+    VkAccessFlags            dstAccessMask;
+    VkImageLayout            newLayout;
+    uint32_t                 srcQueueFamilyIndex;
+    uint32_t                 dstQueueFamilyIndex;
+    std::shared_ptr<IEImage> image;
+    VkImageSubresourceRange  subresourceRange;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEImage>> getImages() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEImage>> getImages() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
 
-	explicit operator VkImageMemoryBarrier() const;
+    explicit operator VkImageMemoryBarrier() const;
 
-	explicit operator VkImageMemoryBarrier2() const;
+    explicit operator VkImageMemoryBarrier2() const;
 };

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IERenderPassBeginInfo.cpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IERenderPassBeginInfo.cpp
@@ -3,25 +3,24 @@
 #include "GraphicsModule/RenderPass/IERenderPass.hpp"
 
 std::vector<std::shared_ptr<IEFramebuffer>> IERenderPassBeginInfo::getFramebuffers() const {
-	return {framebuffer};
+    return {framebuffer};
 }
 
 std::vector<std::shared_ptr<IERenderPass>> IERenderPassBeginInfo::getRenderPasses() const {
-	return {renderPass};
+    return {renderPass};
 }
 
 std::vector<std::shared_ptr<IEDependency>> IERenderPassBeginInfo::getDependencies() const {
-	return {framebuffer, renderPass};
+    return {framebuffer, renderPass};
 }
 
 IERenderPassBeginInfo::operator VkRenderPassBeginInfo() const {
-	return {
-			.sType=VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-			.pNext=pNext,
-			.renderPass=renderPass->renderPass,
-			.framebuffer=framebuffer->getFramebuffer(framebufferIndex),
-			.renderArea=renderArea,
-			.clearValueCount=clearValueCount,
-			.pClearValues=pClearValues
-	};
+    return {
+      .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+      .pNext           = pNext,
+      .renderPass      = renderPass->renderPass,
+      .framebuffer     = framebuffer->getFramebuffer(framebufferIndex),
+      .renderArea      = renderArea,
+      .clearValueCount = clearValueCount,
+      .pClearValues    = pClearValues};
 }

--- a/src/GraphicsModule/CommandBuffer/DependencyStructs/IERenderPassBeginInfo.hpp
+++ b/src/GraphicsModule/CommandBuffer/DependencyStructs/IERenderPassBeginInfo.hpp
@@ -1,23 +1,24 @@
 #pragma once
 
-#include <memory>
 #include "GraphicsModule/RenderPass/IEFramebuffer.hpp"
+
+#include <memory>
 
 class IERenderPassBeginInfo {
 public:
-	const void *pNext{};
-	std::shared_ptr<IERenderPass> renderPass{};
-	std::shared_ptr<IEFramebuffer> framebuffer{};
-	uint8_t framebufferIndex{};
-	VkRect2D renderArea{};
-	uint32_t clearValueCount{};
-	const VkClearValue *pClearValues{};
+    const void                    *pNext{};
+    std::shared_ptr<IERenderPass>  renderPass{};
+    std::shared_ptr<IEFramebuffer> framebuffer{};
+    uint8_t                        framebufferIndex{};
+    VkRect2D                       renderArea{};
+    uint32_t                       clearValueCount{};
+    const VkClearValue            *pClearValues{};
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEFramebuffer>> getFramebuffers() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEFramebuffer>> getFramebuffers() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IERenderPass>> getRenderPasses() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IERenderPass>> getRenderPasses() const;
 
-	[[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IEDependency>> getDependencies() const;
 
-	explicit operator VkRenderPassBeginInfo() const;
+    explicit operator VkRenderPassBeginInfo() const;
 };

--- a/src/GraphicsModule/CommandBuffer/IECommandBuffer.cpp
+++ b/src/GraphicsModule/CommandBuffer/IECommandBuffer.cpp
@@ -1,469 +1,573 @@
-#include <thread>
-
 #include "IECommandBuffer.hpp"
+
+#include "Core/LogModule/IELogger.hpp"
+#include "GraphicsModule/Shader/IEDescriptorSet.hpp"
+#include "GraphicsModule/Shader/IEPipeline.hpp"
 #include "IEDependency.hpp"
 #include "IERenderEngine.hpp"
-#include "GraphicsModule/Shader/IEDescriptorSet.hpp"
-#include "Core/LogModule/IELogger.hpp"
-#include "GraphicsModule/Shader/IEPipeline.hpp"
 
+#include <thread>
 
 void IECommandBuffer::allocate(bool synchronize) {
-	// Prepare
-	VkCommandBufferAllocateInfo allocateInfo{
-			.sType=VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-			.commandPool=commandPool->commandPool,
-			.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-			.commandBufferCount=1
-	};
+    // Prepare
+    VkCommandBufferAllocateInfo allocateInfo{
+      .sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+      .commandPool        = commandPool->commandPool,
+      .level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+      .commandBufferCount = 1};
 
-	// Lock command pool
-	if (synchronize) {
-		commandPool->commandPoolMutex.lock();
-	}
+    // Lock command pool
+    if (synchronize) commandPool->commandPoolMutex.lock();
 
-	// Handle any needed state changes
-	if (status == IE_COMMAND_BUFFER_STATE_INITIAL) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-												 "Attempt to allocate command buffers that are already allocated.");
-	}
+    // Handle any needed state changes
+    if (status == IE_COMMAND_BUFFER_STATE_INITIAL) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Attempt to allocate command buffers that are already allocated."
+        );
+    }
 
-	// Allocate the command buffer
-	VkResult result = vkAllocateCommandBuffers(linkedRenderEngine->device.device, &allocateInfo, &commandBuffer);
-	if (result != VK_SUCCESS) {  // handle any potential errors
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failure to properly allocate command buffers! Error: " +
-																					  IERenderEngine::translateVkResultCodes(result));
-		free(false);
-	} else {  // Change state if no errors
-		status = IE_COMMAND_BUFFER_STATE_INITIAL;
-	}
+    // Allocate the command buffer
+    VkResult result = vkAllocateCommandBuffers(linkedRenderEngine->device.device, &allocateInfo, &commandBuffer);
+    if (result != VK_SUCCESS) {  // handle any potential errors
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failure to properly allocate command buffers! Error: " + IERenderEngine::translateVkResultCodes(result)
+        );
+        free(false);
+    } else {  // Change state if no errors
+        status = IE_COMMAND_BUFFER_STATE_INITIAL;
+    }
 
-	// Unlock command pool
-	if (synchronize) {  // Unlock this command pool if synchronizing
-		commandPool->commandPoolMutex.unlock();
-	}
+    // Unlock command pool
+    if (synchronize)  // Unlock this command pool if synchronizing
+        commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::record(bool synchronize, bool oneTimeSubmit) {
-	// Prepare
-	oneTimeSubmission = oneTimeSubmit;
-	VkCommandBufferBeginInfo beginInfo{
-			.sType=VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-			.flags=static_cast<VkCommandBufferUsageFlags>(oneTimeSubmission ? VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT : 0),
-	};
+    // Prepare
+    oneTimeSubmission = oneTimeSubmit;
+    VkCommandBufferBeginInfo beginInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      .flags = static_cast<VkCommandBufferUsageFlags>(
+        oneTimeSubmission ? VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT : 0
+      ),
+    };
 
-	if (synchronize) {  // Lock this command pool if synchronizing
-		commandPool->commandPoolMutex.lock();
-	}
+    if (synchronize)  // Lock this command pool if synchronizing
+        commandPool->commandPoolMutex.lock();
 
-	// Handle any needed state changes
-	if (status == IE_COMMAND_BUFFER_STATE_RECORDING) {
-		if (synchronize) {
-			commandPool->commandPoolMutex.unlock();
-		}
-		return;
-	}
-	if (status == IE_COMMAND_BUFFER_STATE_NONE) {
-		allocate(false);
-	}
-	if (status >= IE_COMMAND_BUFFER_STATE_EXECUTABLE) {
-		reset(synchronize);
-	}
+    // Handle any needed state changes
+    if (status == IE_COMMAND_BUFFER_STATE_RECORDING) {
+        if (synchronize) commandPool->commandPoolMutex.unlock();
+        return;
+    }
+    if (status == IE_COMMAND_BUFFER_STATE_NONE) allocate(false);
+    if (status >= IE_COMMAND_BUFFER_STATE_EXECUTABLE) reset(synchronize);
 
-	// Begin recording
-	VkResult result = vkBeginCommandBuffer(commandBuffer, &beginInfo);
+    // Begin recording
+    VkResult result = vkBeginCommandBuffer(commandBuffer, &beginInfo);
 
-	// Update state
-	status = IE_COMMAND_BUFFER_STATE_RECORDING;
+    // Update state
+    status = IE_COMMAND_BUFFER_STATE_RECORDING;
 
-	if (synchronize) {  // Unlock this command pool if synchronizing
-		commandPool->commandPoolMutex.unlock();
-	}
-	if (result != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Failure to properly begin command buffer recording! Error: " +
-																					 IERenderEngine::translateVkResultCodes(result));
-	}
+    if (synchronize)  // Unlock this command pool if synchronizing
+        commandPool->commandPoolMutex.unlock();
+    if (result != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Failure to properly begin command buffer recording! Error: " +
+            IERenderEngine::translateVkResultCodes(result)
+        );
+    }
 }
 
 void IECommandBuffer::free(bool synchronize) {
-	wait();
-	if (synchronize) {  // Lock this command pool if synchronizing
-		commandPool->commandPoolMutex.lock();
-	}
-	vkFreeCommandBuffers(linkedRenderEngine->device.device, commandPool->commandPool, 1, &commandBuffer);
-	status = IE_COMMAND_BUFFER_STATE_NONE;
-	if (synchronize) {  // Unlock this command pool if synchronizing
-		commandPool->commandPoolMutex.unlock();
-	}
+    wait();
+    if (synchronize)  // Lock this command pool if synchronizing
+        commandPool->commandPoolMutex.lock();
+    vkFreeCommandBuffers(linkedRenderEngine->device.device, commandPool->commandPool, 1, &commandBuffer);
+    status = IE_COMMAND_BUFFER_STATE_NONE;
+    if (synchronize)  // Unlock this command pool if synchronizing
+        commandPool->commandPoolMutex.unlock();
 }
 
-IECommandBuffer::IECommandBuffer(IERenderEngine *engineLink, const std::shared_ptr<IECommandPool> &parentCommandPool) {
-	linkedRenderEngine = engineLink;
-	commandPool = parentCommandPool;
-	status = IE_COMMAND_BUFFER_STATE_NONE;
+IECommandBuffer::IECommandBuffer(
+  IERenderEngine                       *engineLink,
+  const std::shared_ptr<IECommandPool> &parentCommandPool
+) {
+    linkedRenderEngine = engineLink;
+    commandPool        = parentCommandPool;
+    status             = IE_COMMAND_BUFFER_STATE_NONE;
 }
 
 void IECommandBuffer::reset(bool synchronize) {
-	clearAllDependencies();
+    clearAllDependencies();
 
-	if (synchronize) {  // If synchronizing, lock this command pool
-		commandPool->commandPoolMutex.lock();
-	}
+    if (synchronize)  // If synchronizing, lock this command pool
+        commandPool->commandPoolMutex.lock();
 
-	// Handle any needed state changes
-	if (status == IE_COMMAND_BUFFER_STATE_INVALID) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Attempt to reset a command buffer that is invalid!");
-	}
+    // Handle any needed state changes
+    if (status == IE_COMMAND_BUFFER_STATE_INVALID) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Attempt to reset a command buffer that is invalid!"
+        );
+    }
 
-	// Reset
-	vkResetCommandBuffer(commandBuffer, 0);
+    // Reset
+    vkResetCommandBuffer(commandBuffer, 0);
 
-	// Update new state
-	status = IE_COMMAND_BUFFER_STATE_INITIAL;
+    // Update new state
+    status = IE_COMMAND_BUFFER_STATE_INITIAL;
 
-	if (synchronize) {  // If synchronizing, unlock this command pool
-		commandPool->commandPoolMutex.unlock();
-	}
+    if (synchronize)  // If synchronizing, unlock this command pool
+        commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::finish(bool synchronize) {
-	if (synchronize) {  // If synchronizing, lock this command pool
-		commandPool->commandPoolMutex.lock();
-	}
+    if (synchronize)  // If synchronizing, lock this command pool
+        commandPool->commandPoolMutex.lock();
 
-	// Handle any needed state changes
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Attempt to finish a command buffer that was not recording.");
-	}
+    // Handle any needed state changes
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Attempt to finish a command buffer that was not recording."
+        );
+    }
 
-	// End
-	vkEndCommandBuffer(commandBuffer);
+    // End
+    vkEndCommandBuffer(commandBuffer);
 
-	// Update state
-	status = IE_COMMAND_BUFFER_STATE_EXECUTABLE;
+    // Update state
+    status = IE_COMMAND_BUFFER_STATE_EXECUTABLE;
 
-	if (synchronize) {  // If synchronizing, unlock this command pool
-		commandPool->commandPoolMutex.unlock();
-	}
+    if (synchronize)  // If synchronizing, unlock this command pool
+        commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::execute(VkSemaphore input, VkSemaphore output, VkFence fence) {
     wait();
     commandPool->commandPoolMutex.lock();
-//    executionThread = std::thread{[&] {
-		if (status == IE_COMMAND_BUFFER_STATE_RECORDING) {
-			finish(false);
-		} else if (status != IE_COMMAND_BUFFER_STATE_EXECUTABLE) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Attempt to execute a command buffer that is not recording or executable!");
-		}
-		VkSubmitInfo submitInfo{
-				.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-				.waitSemaphoreCount = input != (VkSemaphore)nullptr,
-				.pWaitSemaphores = &input,
-				.pWaitDstStageMask = new VkPipelineStageFlags{VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT},
-				.commandBufferCount = 1,
-				.pCommandBuffers = &commandBuffer,
-				.signalSemaphoreCount = output != (VkSemaphore)nullptr,
-				.pSignalSemaphores = &output,
-		};
+    //    executionThread = std::thread{[&] {
+    if (status == IE_COMMAND_BUFFER_STATE_RECORDING) {
+        finish(false);
+    } else if (status != IE_COMMAND_BUFFER_STATE_EXECUTABLE) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Attempt to execute a command buffer that is not recording or executable!"
+        );
+    }
+    VkSubmitInfo submitInfo{
+      .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+      .waitSemaphoreCount   = input != (VkSemaphore) nullptr,
+      .pWaitSemaphores      = &input,
+      .pWaitDstStageMask    = new VkPipelineStageFlags{VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT},
+      .commandBufferCount   = 1,
+      .pCommandBuffers      = &commandBuffer,
+      .signalSemaphoreCount = output != (VkSemaphore) nullptr,
+      .pSignalSemaphores    = &output,
+    };
 
-		// Set up fence if not already setup.
-		bool fenceWasNullptr = fence == (VkFence)nullptr;
-		if (fence == (VkFence)nullptr) {
-			VkFenceCreateInfo fenceCreateInfo{
-					.sType=VK_STRUCTURE_TYPE_FENCE_CREATE_INFO
-			};
-			vkCreateFence(linkedRenderEngine->device.device, &fenceCreateInfo, nullptr, &fence);
-		}
-		vkResetFences(linkedRenderEngine->device.device, 1, &fence);
-
-
-		// Lock command buffer
-		status = IE_COMMAND_BUFFER_STATE_PENDING;
-
-		// Submit
-		VkResult result = vkQueueSubmit(commandPool->queue, 1, &submitInfo, fence);
+    // Set up fence if not already setup.
+    bool fenceWasNullptr = fence == (VkFence) nullptr;
+    if (fence == (VkFence) nullptr) {
+        VkFenceCreateInfo fenceCreateInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+        vkCreateFence(linkedRenderEngine->device.device, &fenceCreateInfo, nullptr, &fence);
+    }
+    vkResetFences(linkedRenderEngine->device.device, 1, &fence);
 
 
-		// Wait for GPU to finish then unlock
-		vkWaitForFences(linkedRenderEngine->device.device, 1, &fence, VK_TRUE, UINT64_MAX);
-		if (result != VK_SUCCESS) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Failed to submit command buffer! Error: " + IERenderEngine::translateVkResultCodes(result));
-		}
-		status = oneTimeSubmission ? IE_COMMAND_BUFFER_STATE_INVALID : IE_COMMAND_BUFFER_STATE_EXECUTABLE;
+    // Lock command buffer
+    status = IE_COMMAND_BUFFER_STATE_PENDING;
+
+    // Submit
+    VkResult result = vkQueueSubmit(commandPool->queue, 1, &submitInfo, fence);
 
 
-		// Delete to avoid a memory leak
-		delete submitInfo.pWaitDstStageMask;
+    // Wait for GPU to finish then unlock
+    vkWaitForFences(linkedRenderEngine->device.device, 1, &fence, VK_TRUE, UINT64_MAX);
+    if (result != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to submit command buffer! Error: " + IERenderEngine::translateVkResultCodes(result)
+        );
+    }
+    status = oneTimeSubmission ? IE_COMMAND_BUFFER_STATE_INVALID : IE_COMMAND_BUFFER_STATE_EXECUTABLE;
 
-		if (fenceWasNullptr) {  // destroy the fence if it was created in this function
-			vkDestroyFence(linkedRenderEngine->device.device, fence, nullptr);
-		}
-		oneTimeSubmission = false;
 
-        // All tasks are done. Command buffer can be unlocked.
-		commandPool->commandPoolMutex.unlock();
-//	}};
+    // Delete to avoid a memory leak
+    delete submitInfo.pWaitDstStageMask;
+
+    if (fenceWasNullptr)  // destroy the fence if it was created in this function
+        vkDestroyFence(linkedRenderEngine->device.device, fence, nullptr);
+    oneTimeSubmission = false;
+
+    // All tasks are done. Command buffer can be unlocked.
+    commandPool->commandPoolMutex.unlock();
+    //	}};
 }
 
-void IECommandBuffer::recordPipelineBarrier(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
-											const std::vector<VkMemoryBarrier> &memoryBarriers,
-											const std::vector<IEBufferMemoryBarrier> &bufferMemoryBarriers,
-											const std::vector<IEImageMemoryBarrier> &imageMemoryBarriers) {
-	std::vector<VkBufferMemoryBarrier> bufferBarriers{};
-	bufferBarriers.reserve(bufferMemoryBarriers.size());
-	for (const IEBufferMemoryBarrier &bufferMemoryBarrier: bufferMemoryBarriers) {
-		addDependencies(bufferMemoryBarrier.getDependencies());
-		bufferBarriers.push_back((VkBufferMemoryBarrier) bufferMemoryBarrier);
-	}
-	std::vector<VkImageMemoryBarrier> imageBarriers{};
-	imageBarriers.reserve(imageMemoryBarriers.size());
-	for (const IEImageMemoryBarrier &imageMemoryBarrier: imageMemoryBarriers) {
-		addDependencies(imageMemoryBarrier.getDependencies());
-		imageBarriers.push_back((VkImageMemoryBarrier) imageMemoryBarrier);
-	}
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a pipeline barrier on a command buffer that is not recording!");
-		}
-	}
-	vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarriers.size(), memoryBarriers.data(),
-						 bufferBarriers.size(), bufferBarriers.data(), imageBarriers.size(), imageBarriers.data());
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordPipelineBarrier(
+  VkPipelineStageFlags                      srcStageMask,
+  VkPipelineStageFlags                      dstStageMask,
+  VkDependencyFlags                         dependencyFlags,
+  const std::vector<VkMemoryBarrier>       &memoryBarriers,
+  const std::vector<IEBufferMemoryBarrier> &bufferMemoryBarriers,
+  const std::vector<IEImageMemoryBarrier>  &imageMemoryBarriers
+) {
+    std::vector<VkBufferMemoryBarrier> bufferBarriers{};
+    bufferBarriers.reserve(bufferMemoryBarriers.size());
+    for (const IEBufferMemoryBarrier &bufferMemoryBarrier : bufferMemoryBarriers) {
+        addDependencies(bufferMemoryBarrier.getDependencies());
+        bufferBarriers.push_back((VkBufferMemoryBarrier) bufferMemoryBarrier);
+    }
+    std::vector<VkImageMemoryBarrier> imageBarriers{};
+    imageBarriers.reserve(imageMemoryBarriers.size());
+    for (const IEImageMemoryBarrier &imageMemoryBarrier : imageMemoryBarriers) {
+        addDependencies(imageMemoryBarrier.getDependencies());
+        imageBarriers.push_back((VkImageMemoryBarrier) imageMemoryBarrier);
+    }
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a pipeline barrier on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdPipelineBarrier(
+      commandBuffer,
+      srcStageMask,
+      dstStageMask,
+      dependencyFlags,
+      memoryBarriers.size(),
+      memoryBarriers.data(),
+      bufferBarriers.size(),
+      bufferBarriers.data(),
+      imageBarriers.size(),
+      imageBarriers.data()
+    );
+    commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::recordPipelineBarrier(const IEDependencyInfo *dependencyInfo) {
-	addDependencies(dependencyInfo->getDependencies());
-	commandPool->commandPoolMutex.lock();
-	if (status == IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a pipeline barrier on a command buffer that is not recording!");
-		}
-	}
-	vkCmdPipelineBarrier2(commandBuffer, (const VkDependencyInfo *) dependencyInfo);
-	commandPool->commandPoolMutex.unlock();
+    addDependencies(dependencyInfo->getDependencies());
+    commandPool->commandPoolMutex.lock();
+    if (status == IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a pipeline barrier on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdPipelineBarrier2(commandBuffer, (const VkDependencyInfo *) dependencyInfo);
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordCopyBufferToImage(const std::shared_ptr<IEBuffer> &buffer, const std::shared_ptr<IEImage> &image,
-											  std::vector<VkBufferImageCopy> regions) {
-	addDependencies({image, buffer});
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a buffer to image copy on a command buffer that is not recording!");
-		}
-	}
-	vkCmdCopyBufferToImage(commandBuffer, buffer->buffer, image->image, image->layout, regions.size(), regions.data());
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordCopyBufferToImage(
+  const std::shared_ptr<IEBuffer> &buffer,
+  const std::shared_ptr<IEImage>  &image,
+  std::vector<VkBufferImageCopy>   regions
+) {
+    addDependencies({image, buffer});
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a buffer to image copy on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdCopyBufferToImage(
+      commandBuffer,
+      buffer->buffer,
+      image->image,
+      image->layout,
+      regions.size(),
+      regions.data()
+    );
+    commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::recordCopyBufferToImage(IECopyBufferToImageInfo *copyInfo) {
-	addDependencies(copyInfo->getDependencies());
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a buffer to image copy on a command buffer that is not recording!");
-		}
-	}
-	vkCmdCopyBufferToImage2(commandBuffer, (const VkCopyBufferToImageInfo2 *) copyInfo);
-	commandPool->commandPoolMutex.unlock();
+    addDependencies(copyInfo->getDependencies());
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a buffer to image copy on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdCopyBufferToImage2(commandBuffer, (const VkCopyBufferToImageInfo2 *) copyInfo);
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordBindVertexBuffers(uint32_t firstBinding, uint32_t bindingCount, std::vector<std::shared_ptr<IEBuffer>> buffers, VkDeviceSize *pOffsets) {
-	std::vector<VkBuffer> pVkBuffers{};
-	pVkBuffers.resize(buffers.size());
-	for (size_t i = 0; i < buffers.size(); ++i) {
-		pVkBuffers[i] = buffers[i]->buffer;
-		addDependency((std::shared_ptr<IEDependency>) buffers[i]);
-	}
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a vertex buffer bind on a command buffer that is not recording!");
-		}
-	}
-	vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pVkBuffers.data(), pOffsets);
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordBindVertexBuffers(
+  uint32_t                               firstBinding,
+  uint32_t                               bindingCount,
+  std::vector<std::shared_ptr<IEBuffer>> buffers,
+  VkDeviceSize                          *pOffsets
+) {
+    std::vector<VkBuffer> pVkBuffers{};
+    pVkBuffers.resize(buffers.size());
+    for (size_t i = 0; i < buffers.size(); ++i) {
+        pVkBuffers[i] = buffers[i]->buffer;
+        addDependency((std::shared_ptr<IEDependency>) buffers[i]);
+    }
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a vertex buffer bind on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pVkBuffers.data(), pOffsets);
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordBindVertexBuffers(uint32_t firstBinding, uint32_t bindingCount, const std::vector<std::shared_ptr<IEBuffer>> &buffers, VkDeviceSize *pOffsets, VkDeviceSize *pSizes, VkDeviceSize *pStrides) {
-	std::vector<VkBuffer> pVkBuffers{};
-	pVkBuffers.resize(buffers.size());
-	for (size_t i = 0; i < buffers.size(); ++i) {
-		pVkBuffers[i] = buffers[i]->buffer;
-		addDependency(buffers[i]);
-	}
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a vertex buffer bind on a command buffer that is not recording!");
-		}
-	}
-	vkCmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pVkBuffers.data(), pOffsets, pSizes, pStrides);
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordBindVertexBuffers(
+  uint32_t                                      firstBinding,
+  uint32_t                                      bindingCount,
+  const std::vector<std::shared_ptr<IEBuffer>> &buffers,
+  VkDeviceSize                                 *pOffsets,
+  VkDeviceSize                                 *pSizes,
+  VkDeviceSize                                 *pStrides
+) {
+    std::vector<VkBuffer> pVkBuffers{};
+    pVkBuffers.resize(buffers.size());
+    for (size_t i = 0; i < buffers.size(); ++i) {
+        pVkBuffers[i] = buffers[i]->buffer;
+        addDependency(buffers[i]);
+    }
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a vertex buffer bind on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdBindVertexBuffers2(
+      commandBuffer,
+      firstBinding,
+      bindingCount,
+      pVkBuffers.data(),
+      pOffsets,
+      pSizes,
+      pStrides
+    );
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordBindIndexBuffer(const std::shared_ptr<IEBuffer> &buffer, uint32_t offset, VkIndexType indexType) {
-	addDependency(buffer);
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record an index buffer bind on a command buffer that is not recording!");
-		}
-	}
-	vkCmdBindIndexBuffer(commandBuffer, buffer->buffer, offset, indexType);
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordBindIndexBuffer(
+  const std::shared_ptr<IEBuffer> &buffer,
+  uint32_t                         offset,
+  VkIndexType                      indexType
+) {
+    addDependency(buffer);
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record an index buffer bind on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdBindIndexBuffer(commandBuffer, buffer->buffer, offset, indexType);
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordBindPipeline(VkPipelineBindPoint pipelineBindPoint, const std::shared_ptr<IEPipeline> &pipeline) {
-	addDependency(pipeline);
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a pipeline bind on a command buffer that is not recording!");
-		}
-	}
-	vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline->pipeline);
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordBindPipeline(
+  VkPipelineBindPoint                pipelineBindPoint,
+  const std::shared_ptr<IEPipeline> &pipeline
+) {
+    addDependency(pipeline);
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a pipeline bind on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline->pipeline);
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordBindDescriptorSets(VkPipelineBindPoint pipelineBindPoint, const std::shared_ptr<IEPipeline> &pipeline, uint32_t firstSet, const std::vector<std::shared_ptr<IEDescriptorSet>> &descriptorSets, std::vector<uint32_t> dynamicOffsets) {
-	addDependency(pipeline);
-	std::vector<VkDescriptorSet> pDescriptorSets{};
-	pDescriptorSets.resize(descriptorSets.size());
-	for (size_t i = 0; i < descriptorSets.size(); ++i) {
-		pDescriptorSets[i] = descriptorSets[i]->descriptorSet;
-		addDependency(descriptorSets[i]);
-	}
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a descriptor set bind on a command buffer that is not recording!");
-		}
-	}
-	vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, pipeline->pipelineLayout, firstSet, descriptorSets.size(), pDescriptorSets.data(), dynamicOffsets.size(), dynamicOffsets.data());
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordBindDescriptorSets(
+  VkPipelineBindPoint                                  pipelineBindPoint,
+  const std::shared_ptr<IEPipeline>                   &pipeline,
+  uint32_t                                             firstSet,
+  const std::vector<std::shared_ptr<IEDescriptorSet>> &descriptorSets,
+  std::vector<uint32_t>                                dynamicOffsets
+) {
+    addDependency(pipeline);
+    std::vector<VkDescriptorSet> pDescriptorSets{};
+    pDescriptorSets.resize(descriptorSets.size());
+    for (size_t i = 0; i < descriptorSets.size(); ++i) {
+        pDescriptorSets[i] = descriptorSets[i]->descriptorSet;
+        addDependency(descriptorSets[i]);
+    }
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a descriptor set bind on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdBindDescriptorSets(
+      commandBuffer,
+      pipelineBindPoint,
+      pipeline->pipelineLayout,
+      firstSet,
+      descriptorSets.size(),
+      pDescriptorSets.data(),
+      dynamicOffsets.size(),
+      dynamicOffsets.data()
+    );
+    commandPool->commandPoolMutex.unlock();
 }
 
-void
-IECommandBuffer::recordDrawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record an indexed draw on a command buffer that is not recording!");
-		}
-	}
-	vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordDrawIndexed(
+  uint32_t indexCount,
+  uint32_t instanceCount,
+  uint32_t firstIndex,
+  int32_t  vertexOffset,
+  uint32_t firstInstance
+) {
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record an indexed draw on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+    commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::recordBeginRenderPass(IERenderPassBeginInfo *pRenderPassBegin, VkSubpassContents contents) {
-	addDependencies(pRenderPassBegin->getDependencies());
-	VkRenderPassBeginInfo renderPassBeginInfo = *(VkRenderPassBeginInfo *) pRenderPassBegin;
-	renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-	renderPassBeginInfo.pNext = pRenderPassBegin->pNext;
-	renderPassBeginInfo.renderPass = pRenderPassBegin->renderPass->renderPass;
-	renderPassBeginInfo.framebuffer = pRenderPassBegin->framebuffer->getFramebuffer(pRenderPassBegin->framebufferIndex);
-	renderPassBeginInfo.renderArea = pRenderPassBegin->renderArea;
-	renderPassBeginInfo.clearValueCount = pRenderPassBegin->clearValueCount;
-	renderPassBeginInfo.pClearValues = pRenderPassBegin->pClearValues;
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a render pass beginning on a command buffer that is not recording!");
-		}
-	}
-	vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, contents);
-	commandPool->commandPoolMutex.unlock();
+    addDependencies(pRenderPassBegin->getDependencies());
+    VkRenderPassBeginInfo renderPassBeginInfo = *(VkRenderPassBeginInfo *) pRenderPassBegin;
+    renderPassBeginInfo.sType                 = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    renderPassBeginInfo.pNext                 = pRenderPassBegin->pNext;
+    renderPassBeginInfo.renderPass            = pRenderPassBegin->renderPass->renderPass;
+    renderPassBeginInfo.framebuffer =
+      pRenderPassBegin->framebuffer->getFramebuffer(pRenderPassBegin->framebufferIndex);
+    renderPassBeginInfo.renderArea      = pRenderPassBegin->renderArea;
+    renderPassBeginInfo.clearValueCount = pRenderPassBegin->clearValueCount;
+    renderPassBeginInfo.pClearValues    = pRenderPassBegin->pClearValues;
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a render pass beginning on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, contents);
+    commandPool->commandPoolMutex.unlock();
 }
 
-void IECommandBuffer::recordSetViewport(uint32_t firstViewPort, uint32_t viewPortCount, const VkViewport *pViewPorts) {
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a viewport set on a command buffer that is not recording!");
-		}
-	}
-	vkCmdSetViewport(commandBuffer, firstViewPort, viewPortCount, pViewPorts);
-	commandPool->commandPoolMutex.unlock();
+void IECommandBuffer::recordSetViewport(
+  uint32_t          firstViewPort,
+  uint32_t          viewPortCount,
+  const VkViewport *pViewPorts
+) {
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a viewport set on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdSetViewport(commandBuffer, firstViewPort, viewPortCount, pViewPorts);
+    commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::recordSetScissor(uint32_t firstScissor, uint32_t scissorCount, const VkRect2D *pScissors) {
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a scissor set on a command buffer that is not recording!");
-		}
-	}
-	vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
-	commandPool->commandPoolMutex.unlock();
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a scissor set on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
+    commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::recordEndRenderPass() {
-	commandPool->commandPoolMutex.lock();
-	if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-		record(false);
-		if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-													 "Attempt to record a render pass ending on a command buffer that is not recording!");
-		}
-	}
-	vkCmdEndRenderPass(commandBuffer);
-	commandPool->commandPoolMutex.unlock();
+    commandPool->commandPoolMutex.lock();
+    if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+        record(false);
+        if (status != IE_COMMAND_BUFFER_STATE_RECORDING) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+              "Attempt to record a render pass ending on a command buffer that is not recording!"
+            );
+        }
+    }
+    vkCmdEndRenderPass(commandBuffer);
+    commandPool->commandPoolMutex.unlock();
 }
 
 void IECommandBuffer::wait() {
-	if (executionThread.joinable()) {
-		executionThread.join();
-	}
+    if (executionThread.joinable()) executionThread.join();
 }
 
 void IECommandBuffer::destroy() {
-	free();
-	clearAllDependencies();
+    free();
+    clearAllDependencies();
 }
 
 IECommandBuffer::~IECommandBuffer() {
-	destroy();
+    destroy();
 }
 
 void IECommandBuffer::invalidate() {
-	status = IE_COMMAND_BUFFER_STATE_INVALID;
-	clearAllDependencies();
+    status = IE_COMMAND_BUFFER_STATE_INVALID;
+    clearAllDependencies();
 }
 
 bool IECommandBuffer::canBeDestroyed(const std::shared_ptr<IEDependency> &, bool) {
-	return false;
+    return false;
 }
 
 void IECommandBuffer::freeDependencies() {
-	invalidate();
+    invalidate();
 }

--- a/src/GraphicsModule/CommandBuffer/IECommandBuffer.hpp
+++ b/src/GraphicsModule/CommandBuffer/IECommandBuffer.hpp
@@ -4,107 +4,138 @@ class IECommandPool;
 
 class IERenderEngine;
 
-#include <vulkan/vulkan.h>
-#include <vector>
-#include <variant>
-#include <thread>
-#include <mutex>
-
 #include "Buffer/IEBuffer.hpp"
-#include "Image/IEImage.hpp"
-#include "IEDependent.hpp"
-#include "GraphicsModule/Shader/IEPipeline.hpp"
-#include "CommandBuffer/DependencyStructs/IEDependencyInfo.hpp"
 #include "CommandBuffer/DependencyStructs/IECopyBufferToImageInfo.hpp"
+#include "CommandBuffer/DependencyStructs/IEDependencyInfo.hpp"
 #include "CommandBuffer/DependencyStructs/IERenderPassBeginInfo.hpp"
+#include "GraphicsModule/Shader/IEPipeline.hpp"
+#include "IEDependent.hpp"
+#include "Image/IEImage.hpp"
 
+#include <mutex>
+#include <thread>
+#include <variant>
+#include <vector>
+#include <vulkan/vulkan.h>
 
 typedef enum IECommandBufferStatus {
-	IE_COMMAND_BUFFER_STATE_NONE = 0x0,
-	IE_COMMAND_BUFFER_STATE_INITIAL = 0x1,
-	IE_COMMAND_BUFFER_STATE_RECORDING = 0x2,
-	IE_COMMAND_BUFFER_STATE_EXECUTABLE = 0x3,
-	IE_COMMAND_BUFFER_STATE_PENDING = 0x4,
-	IE_COMMAND_BUFFER_STATE_INVALID = 0x5
+    IE_COMMAND_BUFFER_STATE_NONE       = 0x0,
+    IE_COMMAND_BUFFER_STATE_INITIAL    = 0x1,
+    IE_COMMAND_BUFFER_STATE_RECORDING  = 0x2,
+    IE_COMMAND_BUFFER_STATE_EXECUTABLE = 0x3,
+    IE_COMMAND_BUFFER_STATE_PENDING    = 0x4,
+    IE_COMMAND_BUFFER_STATE_INVALID    = 0x5
 } IECommandBufferStatus;
-
 
 class IECommandBuffer : public IEDependent {
 public:
-	VkCommandBuffer commandBuffer{};
-	std::shared_ptr<IECommandPool> commandPool{};
-	IERenderEngine *linkedRenderEngine{};
-	IECommandBufferStatus status{};
-	bool oneTimeSubmission{false};
-	std::thread executionThread{};
+    VkCommandBuffer                commandBuffer{};
+    std::shared_ptr<IECommandPool> commandPool{};
+    IERenderEngine                *linkedRenderEngine{};
+    IECommandBufferStatus          status{};
+    bool                           oneTimeSubmission{false};
+    std::thread                    executionThread{};
 
-	IECommandBuffer(IERenderEngine *linkedRenderEngine, const std::shared_ptr<IECommandPool> &parentCommandPool);
+    IECommandBuffer(IERenderEngine *linkedRenderEngine, const std::shared_ptr<IECommandPool> &parentCommandPool);
 
-	void wait();
+    void wait();
 
-	/**
-	 * @brief Allocate this command buffer as a primary command buffer.
-	 */
-	void allocate(bool synchronize = true);
+    /**
+     * @brief Allocate this command buffer as a primary command buffer.
+     */
+    void allocate(bool synchronize = true);
 
-	/**
-	 * @brief Prepare this command buffer for recording.
-	 */
-	void record(bool synchronize = true, bool oneTimeSubmit = false);
+    /**
+     * @brief Prepare this command buffer for recording.
+     */
+    void record(bool synchronize = true, bool oneTimeSubmit = false);
 
-	void free(bool synchronize = true);
+    void free(bool synchronize = true);
 
-	void reset(bool synchronize = true);
+    void reset(bool synchronize = true);
 
-	void execute(VkSemaphore input = (VkSemaphore)(void *)nullptr, VkSemaphore output = (VkSemaphore)(void *)nullptr, VkFence fence = (VkFence)(void *)nullptr);
+    void execute(
+      VkSemaphore input  = (VkSemaphore) (void *) nullptr,
+      VkSemaphore output = (VkSemaphore) (void *) nullptr,
+      VkFence     fence  = (VkFence) (void *) nullptr
+    );
 
-	void finish(bool synchronize = true);
+    void finish(bool synchronize = true);
 
-	void recordPipelineBarrier(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
-							   const std::vector<VkMemoryBarrier> &memoryBarriers, const std::vector<IEBufferMemoryBarrier> &bufferMemoryBarriers,
-							   const std::vector<IEImageMemoryBarrier> &imageMemoryBarriers);
+    void recordPipelineBarrier(
+      VkPipelineStageFlags                      srcStageMask,
+      VkPipelineStageFlags                      dstStageMask,
+      VkDependencyFlags                         dependencyFlags,
+      const std::vector<VkMemoryBarrier>       &memoryBarriers,
+      const std::vector<IEBufferMemoryBarrier> &bufferMemoryBarriers,
+      const std::vector<IEImageMemoryBarrier>  &imageMemoryBarriers
+    );
 
-	void recordPipelineBarrier(const IEDependencyInfo *dependencyInfo);
+    void recordPipelineBarrier(const IEDependencyInfo *dependencyInfo);
 
-	void
-	recordCopyBufferToImage(const std::shared_ptr<IEBuffer> &buffer, const std::shared_ptr<IEImage> &image, std::vector<VkBufferImageCopy> regions);
+    void recordCopyBufferToImage(
+      const std::shared_ptr<IEBuffer> &buffer,
+      const std::shared_ptr<IEImage>  &image,
+      std::vector<VkBufferImageCopy>   regions
+    );
 
-	void recordCopyBufferToImage(IECopyBufferToImageInfo *copyInfo);
+    void recordCopyBufferToImage(IECopyBufferToImageInfo *copyInfo);
 
-	void
-	recordBindVertexBuffers(uint32_t firstBinding, uint32_t bindingCount, std::vector<std::shared_ptr<IEBuffer>> buffers, VkDeviceSize *pOffsets);
+    void recordBindVertexBuffers(
+      uint32_t                               firstBinding,
+      uint32_t                               bindingCount,
+      std::vector<std::shared_ptr<IEBuffer>> buffers,
+      VkDeviceSize                          *pOffsets
+    );
 
-	void recordBindVertexBuffers(uint32_t firstBinding, uint32_t bindingCount, const std::vector<std::shared_ptr<IEBuffer>> &buffers,
-								 VkDeviceSize *pOffsets, VkDeviceSize *pSizes, VkDeviceSize *pStrides);
+    void recordBindVertexBuffers(
+      uint32_t                                      firstBinding,
+      uint32_t                                      bindingCount,
+      const std::vector<std::shared_ptr<IEBuffer>> &buffers,
+      VkDeviceSize                                 *pOffsets,
+      VkDeviceSize                                 *pSizes,
+      VkDeviceSize                                 *pStrides
+    );
 
-	void recordBindPipeline(VkPipelineBindPoint pipelineBindPoint, const std::shared_ptr<IEPipeline> &pipeline);
+    void recordBindPipeline(VkPipelineBindPoint pipelineBindPoint, const std::shared_ptr<IEPipeline> &pipeline);
 
-	void recordBindDescriptorSets(VkPipelineBindPoint pipelineBindPoint, const std::shared_ptr<IEPipeline> &pipeline, uint32_t firstSet,
-								  const std::vector<std::shared_ptr<IEDescriptorSet>> &descriptorSets, std::vector<uint32_t> dynamicOffsets);
+    void recordBindDescriptorSets(
+      VkPipelineBindPoint                                  pipelineBindPoint,
+      const std::shared_ptr<IEPipeline>                   &pipeline,
+      uint32_t                                             firstSet,
+      const std::vector<std::shared_ptr<IEDescriptorSet>> &descriptorSets,
+      std::vector<uint32_t>                                dynamicOffsets
+    );
 
-	void recordDrawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
+    void recordDrawIndexed(
+      uint32_t indexCount,
+      uint32_t instanceCount,
+      uint32_t firstIndex,
+      int32_t  vertexOffset,
+      uint32_t firstInstance
+    );
 
-	void recordBindIndexBuffer(const std::shared_ptr<IEBuffer> &buffer, uint32_t offset, VkIndexType indexType);
+    void recordBindIndexBuffer(const std::shared_ptr<IEBuffer> &buffer, uint32_t offset, VkIndexType indexType);
 
-	void recordBeginRenderPass(IERenderPassBeginInfo *pRenderPassBegin, VkSubpassContents contents);
+    void recordBeginRenderPass(IERenderPassBeginInfo *pRenderPassBegin, VkSubpassContents contents);
 
-	void recordSetViewport(uint32_t firstViewPort, uint32_t viewPortCount, const VkViewport *pViewPorts);
+    void recordSetViewport(uint32_t firstViewPort, uint32_t viewPortCount, const VkViewport *pViewPorts);
 
-	void recordSetScissor(uint32_t firstScissor, uint32_t scissorCount, const VkRect2D *pScissors);
+    void recordSetScissor(uint32_t firstScissor, uint32_t scissorCount, const VkRect2D *pScissors);
 
-	void recordEndRenderPass();
+    void recordEndRenderPass();
 
-	void destroy();
+    void destroy();
 
-	~IECommandBuffer();
+    ~IECommandBuffer();
 
-	IECommandBuffer(const IECommandBuffer &source) = delete;
+    IECommandBuffer(const IECommandBuffer &source) = delete;
 
-	IECommandBuffer(IECommandBuffer &&source) noexcept {};
+    IECommandBuffer(IECommandBuffer &&source) noexcept {};
 
-	void invalidate() override;
+    void invalidate() override;
 
-	bool canBeDestroyed(const std::shared_ptr<IEDependency> &, bool) override;
+    bool canBeDestroyed(const std::shared_ptr<IEDependency> &, bool) override;
 
-	void freeDependencies() override;
+    void freeDependencies() override;
 };

--- a/src/GraphicsModule/CommandBuffer/IECommandPool.cpp
+++ b/src/GraphicsModule/CommandBuffer/IECommandPool.cpp
@@ -8,52 +8,51 @@
 #include "Core/LogModule/IELogger.hpp"
 
 void IECommandPool::create(IERenderEngine *engineLink, IECommandPool::CreateInfo *createInfo) {
-	linkedRenderEngine = engineLink;
-	createdWith = *createInfo;
-	queue = linkedRenderEngine->device.get_queue(createdWith.commandQueue).value();
-	VkCommandPoolCreateInfo commandPoolCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-			.flags=static_cast<VkCommandPoolCreateFlags>(createInfo->flags),
-			.queueFamilyIndex=linkedRenderEngine->device.get_queue_index(createInfo->commandQueue).value()
-	};
-	if (vkCreateCommandPool(linkedRenderEngine->device.device, &commandPoolCreateInfo, nullptr, &commandPool) != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG, "Failed to create command pool!");
-	}
-	deletionQueue.emplace_back([&] {
-		vkDestroyCommandPool(linkedRenderEngine->device.device, commandPool, nullptr);
-	});
+    linkedRenderEngine = engineLink;
+    createdWith        = *createInfo;
+    queue              = linkedRenderEngine->device.get_queue(createdWith.commandQueue).value();
+    VkCommandPoolCreateInfo commandPoolCreateInfo{
+      .sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+      .flags            = static_cast<VkCommandPoolCreateFlags>(createInfo->flags),
+      .queueFamilyIndex = linkedRenderEngine->device.get_queue_index(createInfo->commandQueue).value()};
+    if (vkCreateCommandPool(linkedRenderEngine->device.device, &commandPoolCreateInfo, nullptr, &commandPool) != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG,
+          "Failed to create command pool!"
+        );
+    }
+    deletionQueue.emplace_back([&] {
+        vkDestroyCommandPool(linkedRenderEngine->device.device, commandPool, nullptr);
+    });
 }
 
 void IECommandPool::prepareCommandBuffers(uint32_t commandBufferCount) {
-	uint32_t startIndex = commandBuffers.size();
-	commandBuffers.reserve(commandBufferCount);
-	for (; startIndex < commandBufferCount; ++startIndex) {
-		commandBuffers.push_back(std::make_shared<IECommandBuffer>(linkedRenderEngine, shared_from_this()));
-	}
+    uint32_t startIndex = commandBuffers.size();
+    commandBuffers.reserve(commandBufferCount);
+    for (; startIndex < commandBufferCount; ++startIndex)
+        commandBuffers.push_back(std::make_shared<IECommandBuffer>(linkedRenderEngine, shared_from_this()));
 }
 
 std::shared_ptr<IECommandBuffer> IECommandPool::index(uint32_t index) {
-	if (index <= commandBuffers.size()) {
-		if (index == commandBuffers.size()) {
-			commandBuffers.push_back(std::make_shared<IECommandBuffer>(linkedRenderEngine, shared_from_this()));
-		}
-		return commandBuffers[index];
-	}
-	linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to access a command buffer that does not exist!");
-	return commandBuffers[commandBuffers.size() - 1];
+    if (index <= commandBuffers.size()) {
+        if (index == commandBuffers.size())
+            commandBuffers.push_back(std::make_shared<IECommandBuffer>(linkedRenderEngine, shared_from_this()));
+        return commandBuffers[index];
+    }
+    linkedRenderEngine->settings->logger.log(
+      ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+      "Attempt to access a command buffer that does not exist!"
+    );
+    return commandBuffers[commandBuffers.size() - 1];
 }
 
 void IECommandPool::destroy() {
-	for (const std::shared_ptr<IECommandBuffer>& commandBuffer: commandBuffers) {
-		commandBuffer->destroy();
-	}
-	commandBuffers.clear();
-	for (const std::function<void()> &function: deletionQueue) {
-		function();
-	}
-	deletionQueue.clear();
+    for (const std::shared_ptr<IECommandBuffer> &commandBuffer : commandBuffers) commandBuffer->destroy();
+    commandBuffers.clear();
+    for (const std::function<void()> &function : deletionQueue) function();
+    deletionQueue.clear();
 }
 
 IECommandPool::~IECommandPool() {
-	destroy();
+    destroy();
 }

--- a/src/GraphicsModule/CommandBuffer/IECommandPool.hpp
+++ b/src/GraphicsModule/CommandBuffer/IECommandPool.hpp
@@ -9,37 +9,36 @@ class IERenderEngine;
 
 // External dependencies
 #include <VkBootstrap.h>
-
 #include <vulkan/vulkan.h>
 
 // System dependencies
-#include <vector>
 #include <cstdint>
-
+#include <vector>
 
 class IECommandPool : public std::enable_shared_from_this<IECommandPool> {
 public:
-	struct CreateInfo {
-	public:
-		VkCommandPoolCreateFlagBits flags{
-				static_cast<VkCommandPoolCreateFlagBits>(VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)};
-		vkb::QueueType commandQueue;
-	} createdWith{};
+    struct CreateInfo {
+    public:
+        VkCommandPoolCreateFlagBits flags{static_cast<VkCommandPoolCreateFlagBits>(
+          VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
+        )};
+        vkb::QueueType              commandQueue;
+    } createdWith{};
 
-	VkCommandPool commandPool{};
-	std::vector<std::shared_ptr<IECommandBuffer>> commandBuffers{};
-	IERenderEngine *linkedRenderEngine{};
-	VkQueue queue;
-	std::mutex commandPoolMutex{};
-	std::vector<std::function<void()>> deletionQueue{};
+    VkCommandPool                                 commandPool{};
+    std::vector<std::shared_ptr<IECommandBuffer>> commandBuffers{};
+    IERenderEngine                               *linkedRenderEngine{};
+    VkQueue                                       queue;
+    std::mutex                                    commandPoolMutex{};
+    std::vector<std::function<void()>>            deletionQueue{};
 
-	void create(IERenderEngine *engineLink, CreateInfo *createInfo);
+    void create(IERenderEngine *engineLink, CreateInfo *createInfo);
 
-	void destroy();
+    void destroy();
 
-	~IECommandPool();
+    ~IECommandPool();
 
-	void prepareCommandBuffers(uint32_t commandBufferCount);
+    void prepareCommandBuffers(uint32_t commandBufferCount);
 
-	std::shared_ptr<IECommandBuffer> index(uint32_t index);
+    std::shared_ptr<IECommandBuffer> index(uint32_t index);
 };

--- a/src/GraphicsModule/CommandBuffer/IEDependency.cpp
+++ b/src/GraphicsModule/CommandBuffer/IEDependency.cpp
@@ -1,67 +1,57 @@
-#include <algorithm>
 #include "IEDependency.hpp"
 
-#include "IEDependent.hpp"
-
-#include "Image/IEImage.hpp"
 #include "Buffer/IEBuffer.hpp"
-#include "GraphicsModule/Shader/IEPipeline.hpp"
-#include "GraphicsModule/Shader/IEDescriptorSet.hpp"
 #include "GraphicsModule/RenderPass/IERenderPass.hpp"
+#include "GraphicsModule/Shader/IEDescriptorSet.hpp"
+#include "GraphicsModule/Shader/IEPipeline.hpp"
+#include "IEDependent.hpp"
+#include "Image/IEImage.hpp"
+
+#include <algorithm>
 
 void IEDependency::addDependent(IEDependent *newDependent) {
-	dependents.push_back(newDependent);
+    dependents.push_back(newDependent);
 }
 
 void IEDependency::addDependent(IEDependent &newDependent) {
-	dependents.push_back(&newDependent);
+    dependents.push_back(&newDependent);
 }
 
 void IEDependency::addDependents(const std::vector<IEDependent *> &newDependents) {
-	dependents.insert(dependents.begin(), newDependents.begin(), newDependents.end());
+    dependents.insert(dependents.begin(), newDependents.begin(), newDependents.end());
 }
 
 void IEDependency::addDependents(std::vector<IEDependent> &newDependents) {
-	dependents.reserve(dependents.size() + newDependents.size());
-	for (IEDependent &dependent: newDependents) {
-		addDependent(dependent);
-	}
+    dependents.reserve(dependents.size() + newDependents.size());
+    for (IEDependent &dependent : newDependents) addDependent(dependent);
 }
 
 void IEDependency::removeDependent(IEDependent *oldDependent) {
-	dependents.erase(std::find_if(dependents.begin(), dependents.end(), [&](IEDependent *item) {
-		return item == oldDependent;
-	}));
+    dependents.erase(std::find_if(dependents.begin(), dependents.end(), [&](IEDependent *item) {
+        return item == oldDependent;
+    }));
 }
 
 void IEDependency::removeDependent(IEDependent &oldDependent) {
-	dependents.erase(std::find_if(dependents.begin(), dependents.end(), [&](IEDependent *item) {
-		return item == &oldDependent;
-	}));
+    dependents.erase(std::find_if(dependents.begin(), dependents.end(), [&](IEDependent *item) {
+        return item == &oldDependent;
+    }));
 }
 
 void IEDependency::removeDependents(const std::vector<IEDependent *> &oldDependents) {
-	for (IEDependent *dependent: oldDependents) {
-		removeDependent(dependent);
-	}
+    for (IEDependent *dependent : oldDependents) removeDependent(dependent);
 }
 
 void IEDependency::removeDependents(std::vector<IEDependent> &oldDependents) {
-	for (IEDependent &dependent: oldDependents) {
-		removeDependent(dependent);
-	}
+    for (IEDependent &dependent : oldDependents) removeDependent(dependent);
 }
 
 void IEDependency::invalidateDependents() {
-	for (IEDependent *dependent: dependents) {
-		dependent->invalidate();
-	}
+    for (IEDependent *dependent : dependents) dependent->invalidate();
 }
 
 bool IEDependency::canBeDestroyed(bool force) {
-	bool result = true;
-	for (IEDependent *dependent: dependents) {
-		result |= dependent->canBeDestroyed(this, force);
-	}
-	return result;
+    bool result = true;
+    for (IEDependent *dependent : dependents) result |= dependent->canBeDestroyed(this, force);
+    return result;
 }

--- a/src/GraphicsModule/CommandBuffer/IEDependency.hpp
+++ b/src/GraphicsModule/CommandBuffer/IEDependency.hpp
@@ -14,36 +14,35 @@ class IEDescriptorSet;
 
 class IERenderPass;
 
+#include <memory>
+#include <string>
 #include <vector>
 #include <vulkan/vulkan.h>
-#include <string>
-#include <memory>
-
 
 class IEDependency {
 private:
-	std::vector<IEDependent *> dependents{};
+    std::vector<IEDependent *> dependents{};
 
 public:
-	void addDependent(IEDependent *);
+    void addDependent(IEDependent *);
 
-	void addDependent(IEDependent &);
+    void addDependent(IEDependent &);
 
-	void addDependents(const std::vector<IEDependent *> &);
+    void addDependents(const std::vector<IEDependent *> &);
 
-	void addDependents(std::vector<IEDependent> &);
+    void addDependents(std::vector<IEDependent> &);
 
-	void removeDependent(IEDependent *);
+    void removeDependent(IEDependent *);
 
-	void removeDependent(IEDependent &);
+    void removeDependent(IEDependent &);
 
-	void removeDependents(const std::vector<IEDependent *> &);
+    void removeDependents(const std::vector<IEDependent *> &);
 
-	void removeDependents(std::vector<IEDependent> &);
+    void removeDependents(std::vector<IEDependent> &);
 
-	void invalidateDependents();
+    void invalidateDependents();
 
-	bool canBeDestroyed(bool= false);
+    bool canBeDestroyed(bool = false);
 
-	virtual ~IEDependency() = default;
+    virtual ~IEDependency() = default;
 };

--- a/src/GraphicsModule/CommandBuffer/IEDependent.cpp
+++ b/src/GraphicsModule/CommandBuffer/IEDependent.cpp
@@ -1,53 +1,51 @@
-#include <algorithm>
-#include <memory>
-#include <iostream>
 #include "IEDependent.hpp"
+
 #include "Buffer/IEBuffer.hpp"
 #include "GraphicsModule/RenderPass/IEFramebuffer.hpp"
-
 #include "IEDependency.hpp"
 
+#include <algorithm>
+#include <iostream>
+#include <memory>
+
 void IEDependent::addDependency(const std::shared_ptr<IEDependency> &newDependency) {
-	if (!isDependentOn(newDependency)) {
-		dependencies.push_back(newDependency);
-	}
+    if (!isDependentOn(newDependency)) dependencies.push_back(newDependency);
 }
 
 void IEDependent::addDependencies(const std::vector<std::shared_ptr<IEDependency>> &newDependencies) {
-	for (const std::shared_ptr<IEDependency> &newDependency: newDependencies) {
-		addDependency(newDependency);
-	}
+    for (const std::shared_ptr<IEDependency> &newDependency : newDependencies) addDependency(newDependency);
 }
 
 void IEDependent::removeDependency(const std::shared_ptr<IEDependency> &oldDependency) {
-	dependencies.erase(std::find_if(dependencies.begin(), dependencies.end(), [&](const std::shared_ptr<IEDependency> &thisDependency) {
-		return thisDependency == oldDependency;
-	}));
+    dependencies.erase(std::find_if(
+      dependencies.begin(),
+      dependencies.end(),
+      [&](const std::shared_ptr<IEDependency> &thisDependency) { return thisDependency == oldDependency; }
+    ));
 }
 
 void IEDependent::removeDependencies(const std::vector<std::shared_ptr<IEDependency>> &oldDependencies) {
-	for (const std::shared_ptr<IEDependency> &oldDependency: oldDependencies) {
-		removeDependency(oldDependency);
-	}
+    for (const std::shared_ptr<IEDependency> &oldDependency : oldDependencies) removeDependency(oldDependency);
 }
 
 uint32_t IEDependent::dependencyCount() {
-	return dependencies.size();
+    return dependencies.size();
 }
 
 void IEDependent::clearAllDependencies() {
-	dependencies.clear();
+    dependencies.clear();
 }
 
 bool IEDependent::canBeDestroyed(const std::shared_ptr<IEDependency> &, bool) {
-	return false;
+    return false;
 }
 
 bool IEDependent::canBeDestroyed(IEDependency *, bool) {
-	return false;
+    return false;
 }
 
 bool IEDependent::isDependentOn(const std::shared_ptr<IEDependency> &dependency) {
-	return std::any_of(dependencies.begin(), dependencies.end(),
-					   [&](const std::shared_ptr<IEDependency> &item) { return item.get() == dependency.get(); });
+    return std::any_of(dependencies.begin(), dependencies.end(), [&](const std::shared_ptr<IEDependency> &item) {
+        return item.get() == dependency.get();
+    });
 }

--- a/src/GraphicsModule/CommandBuffer/IEDependent.hpp
+++ b/src/GraphicsModule/CommandBuffer/IEDependent.hpp
@@ -2,34 +2,35 @@
 
 class IEDependency;
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 class IEDependent {
 private:
-	std::vector<std::shared_ptr<IEDependency>> dependencies{};
+    std::vector<std::shared_ptr<IEDependency>> dependencies{};
 
 protected:
-	void addDependency(const std::shared_ptr<IEDependency> &);
+    void addDependency(const std::shared_ptr<IEDependency> &);
 
-	void addDependencies(const std::vector<std::shared_ptr<IEDependency>> &);
+    void addDependencies(const std::vector<std::shared_ptr<IEDependency>> &);
 
-	void removeDependency(const std::shared_ptr<IEDependency> &);
+    void removeDependency(const std::shared_ptr<IEDependency> &);
 
-	void removeDependencies(const std::vector<std::shared_ptr<IEDependency>> &oldDependencies);
+    void removeDependencies(const std::vector<std::shared_ptr<IEDependency>> &oldDependencies);
 
 public:
-	void clearAllDependencies();
+    void clearAllDependencies();
 
-	uint32_t dependencyCount();
+    uint32_t dependencyCount();
 
-	virtual bool canBeDestroyed(const std::shared_ptr<IEDependency> &, bool);;
+    virtual bool canBeDestroyed(const std::shared_ptr<IEDependency> &, bool);
+    ;
 
-	virtual void freeDependencies() {};
+    virtual void freeDependencies(){};
 
-	virtual void invalidate() {};
+    virtual void invalidate(){};
 
-	bool isDependentOn(const std::shared_ptr<IEDependency> &dependency);
+    bool isDependentOn(const std::shared_ptr<IEDependency> &dependency);
 
-	bool canBeDestroyed(IEDependency *, bool);
+    bool canBeDestroyed(IEDependency *, bool);
 };

--- a/src/GraphicsModule/DefaultShaders/Vulkan/fragmentShader.frag
+++ b/src/GraphicsModule/DefaultShaders/Vulkan/fragmentShader.frag
@@ -1,7 +1,7 @@
 #version 460
-#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_separate_shader_objects: enable
 
-layout(binding = 0) uniform CameraData {
+layout (binding = 0) uniform CameraData {
     mat4 projectionViewModelMatrix;
     mat4 modelMatrix;
     mat4 normalMatrix;
@@ -9,14 +9,14 @@ layout(binding = 0) uniform CameraData {
     float time;
 } cameraData;
 
-layout(binding = 1) uniform sampler2D diffuseTexture;
+layout (binding = 1) uniform sampler2D diffuseTexture;
 //layout(binding = 2) uniform sampler2D specularTexture;
 
-layout(location = 0) in vec2 fragmentTextureCoordinates;
-layout(location = 1) in vec3 interpolatedNormal;
-layout(location = 2) in vec3 fragmentPosition;
+layout (location = 0) in vec2 fragmentTextureCoordinates;
+layout (location = 1) in vec3 interpolatedNormal;
+layout (location = 2) in vec3 fragmentPosition;
 
-layout(location = 0) out vec4 fragmentColor;
+layout (location = 0) out vec4 fragmentColor;
 
 const vec3 lightPosition = vec3(0.0f, 0.0f, 2.0f);
 const vec3 lightColor = vec3(1.0f, 1.0f, 1.0f);
@@ -36,9 +36,9 @@ void main() {
     vec3 diffuse = vec3(texture(diffuseTexture, fragmentTextureCoordinates)) * max(dot(normalizedInterpolatedNormal, lightDirection), 0.0f) * lightColor * lightIntensityAfterAttenuation;
     vec3 ambient = ambientStrength * lightColor;
     vec3 viewDirection = normalize(cameraData.position - fragmentPosition);
-//    vec3 specular = vec3(texture(specularTexture, fragmentTextureCoordinates)) * pow(max(dot(normalizedInterpolatedNormal, normalize(lightDirection + viewDirection)), 0.0f), 16.0f) * lightColor * lightIntensityAfterAttenuation;
-//    fragmentColor = aces(vec4((ambient + diffuse + specular), 1.0f));
+    //    vec3 specular = vec3(texture(specularTexture, fragmentTextureCoordinates)) * pow(max(dot(normalizedInterpolatedNormal, normalize(lightDirection + viewDirection)), 0.0f), 16.0f) * lightColor * lightIntensityAfterAttenuation;
+    //    fragmentColor = aces(vec4((ambient + diffuse + specular), 1.0f));
     fragmentColor = aces(vec4((ambient + diffuse), 1.0f));
-//    fragmentColor = aces(vec4(texture(diffuseTexture, fragmentTextureCoordinates)));
-//    fragmentColor = aces(vec4(1));
+    //    fragmentColor = aces(vec4(texture(diffuseTexture, fragmentTextureCoordinates)));
+    //    fragmentColor = aces(vec4(1));
 }

--- a/src/GraphicsModule/DefaultShaders/Vulkan/vertexShader.vert
+++ b/src/GraphicsModule/DefaultShaders/Vulkan/vertexShader.vert
@@ -1,7 +1,7 @@
 #version 460
-#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_separate_shader_objects: enable
 
-layout(binding = 0) uniform CameraData {
+layout (binding = 0) uniform CameraData {
     mat4 projectionViewModelMatrix;
     mat4 modelMatrix;
     mat4 normalMatrix;
@@ -9,17 +9,17 @@ layout(binding = 0) uniform CameraData {
     float time;
 } cameraData;
 
-layout(location = 0) in vec3 vertexPosition;
-layout(location = 1) in vec3 vertexColor;
-layout(location = 2) in vec2 vertexTextureCoordinates;
-layout(location = 3) in vec3 vertexNormal;
-layout(location = 4) in vec3 vertexTangent;
-layout(location = 5) in vec3 vertexBitangent;
+layout (location = 0) in vec3 vertexPosition;
+layout (location = 1) in vec3 vertexColor;
+layout (location = 2) in vec2 vertexTextureCoordinates;
+layout (location = 3) in vec3 vertexNormal;
+layout (location = 4) in vec3 vertexTangent;
+layout (location = 5) in vec3 vertexBitangent;
 
 
-layout(location = 0) out vec2 fragmentTextureCoordinates;
-layout(location = 1) out vec3 interpolatedNormal;
-layout(location = 2) out vec3 fragmentPosition;
+layout (location = 0) out vec2 fragmentTextureCoordinates;
+layout (location = 1) out vec3 interpolatedNormal;
+layout (location = 2) out vec3 fragmentPosition;
 
 void main() {
     fragmentPosition = vec3(cameraData.modelMatrix * vec4(vertexPosition, 1.0f));

--- a/src/GraphicsModule/IEAPI.cpp
+++ b/src/GraphicsModule/IEAPI.cpp
@@ -11,28 +11,28 @@
 #include <vulkan/vulkan.h>
 
 #define GLEW_IMPLEMENTATION
+
 #include <include/GL/glew.h>
 
-
 IEAPI::IEAPI(const std::string &apiName) {
-	name = apiName;
+    name = apiName;
 }
 
 IEAPI::IEAPI() = default;
 
 IEVersion IEAPI::getHighestSupportedVersion(IERenderEngine *linkedRenderEngine) const {
-	IEVersion temporaryVersion;
-	if (name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		VkPhysicalDeviceProperties properties;
-		vkGetPhysicalDeviceProperties(linkedRenderEngine->device.physical_device, &properties);
-		temporaryVersion = IEVersion(properties.apiVersion);
-	}
-	if (name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		GLint OpenGLVersionMajor, OpenGLVersionMinor;
-		glGetIntegerv(GL_MAJOR_VERSION, &OpenGLVersionMajor);
-		glGetIntegerv(GL_MINOR_VERSION, &OpenGLVersionMinor);
-		temporaryVersion = IEVersion{static_cast<uint32_t>(OpenGLVersionMajor), static_cast<uint32_t>(OpenGLVersionMinor), 0};
-	}
-	return temporaryVersion;
+    IEVersion temporaryVersion;
+    if (name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        VkPhysicalDeviceProperties properties;
+        vkGetPhysicalDeviceProperties(linkedRenderEngine->device.physical_device, &properties);
+        temporaryVersion = IEVersion(properties.apiVersion);
+    }
+    if (name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        GLint OpenGLVersionMajor, OpenGLVersionMinor;
+        glGetIntegerv(GL_MAJOR_VERSION, &OpenGLVersionMajor);
+        glGetIntegerv(GL_MINOR_VERSION, &OpenGLVersionMinor);
+        temporaryVersion =
+          IEVersion{static_cast<uint32_t>(OpenGLVersionMajor), static_cast<uint32_t>(OpenGLVersionMinor), 0};
+    }
+    return temporaryVersion;
 }
-

--- a/src/GraphicsModule/IEAPI.hpp
+++ b/src/GraphicsModule/IEAPI.hpp
@@ -16,16 +16,16 @@ class IERenderEngine;
 
 class IEAPI {
 public:
-	explicit IEAPI(const std::string &apiName);
+    explicit IEAPI(const std::string &apiName);
 
-	IEAPI();
+    IEAPI();
 
-	std::string name{}; // The name of the API to use
-	IEVersion version{}; // The version of the API to use
+    std::string name{};     // The name of the API to use
+    IEVersion   version{};  // The version of the API to use
 
-	/**
-	 * @brief Finds the highest supported API version.
-	 * @return An IEVersion populated with all the data about the highest supported API version
-	 */
-	IEVersion getHighestSupportedVersion(IERenderEngine *linkedRenderEngine) const;
+    /**
+     * @brief Finds the highest supported API version.
+     * @return An IEVersion populated with all the data about the highest supported API version
+     */
+    IEVersion getHighestSupportedVersion(IERenderEngine *linkedRenderEngine) const;
 };

--- a/src/GraphicsModule/IECamera.cpp
+++ b/src/GraphicsModule/IECamera.cpp
@@ -6,28 +6,38 @@
 
 /* Include external dependencies. */
 #define GLM_FORCE_RADIANS
+
 #include <glm/ext/matrix_clip_space.hpp>
 
-
 void IECamera::create(IERenderEngine *engineLink) {
-	linkedRenderEngine = engineLink;
-	updateSettings();
-	projectionMatrix = glm::perspective(glm::radians(fov), aspectRatio, 0.01, linkedRenderEngine->settings->renderDistance);
+    linkedRenderEngine = engineLink;
+    updateSettings();
+    projectionMatrix =
+      glm::perspective(glm::radians(fov), aspectRatio, 0.01, linkedRenderEngine->settings->renderDistance);
 }
 
 void IECamera::update() {
-	front = glm::normalize(glm::vec3{cos(glm::radians(yaw)) * cos(glm::radians(pitch)), sin(glm::radians(yaw)) * cos(glm::radians(pitch)),
-									 sin(glm::radians(pitch))});
-	right = glm::normalize(glm::cross(front, up));
-	viewMatrix = {glm::lookAt(position, position + front, up)};
-	projectionMatrix = {glm::perspective(glm::radians(horizontalFOV), double((*linkedRenderEngine->settings->currentResolution)[0]) /
-																	  (*linkedRenderEngine->settings->currentResolution)[1], 0.01,
-										 linkedRenderEngine->settings->renderDistance)};
-	if (linkedRenderEngine->API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) projectionMatrix[1][1] *= -1.0f;
+    front            = glm::normalize(glm::vec3{
+      cos(glm::radians(yaw)) * cos(glm::radians(pitch)),
+      sin(glm::radians(yaw)) * cos(glm::radians(pitch)),
+      sin(glm::radians(pitch))});
+    right            = glm::normalize(glm::cross(front, up));
+    viewMatrix       = {glm::lookAt(position, position + front, up)};
+    projectionMatrix = {glm::perspective(
+      glm::radians(horizontalFOV),
+      double((*linkedRenderEngine->settings->currentResolution)[0]) /
+        (*linkedRenderEngine->settings->currentResolution)[1],
+      0.01,
+      linkedRenderEngine->settings->renderDistance
+    )};
+    if (linkedRenderEngine->API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) projectionMatrix[1][1] *= -1.0f;
 }
 
 void IECamera::updateSettings() {
-	aspectRatio = double((*linkedRenderEngine->settings->currentResolution)[0]) / (*linkedRenderEngine->settings->currentResolution)[1];
-	fov = linkedRenderEngine->settings->fov;
-	horizontalFOV = tanh(tan(linkedRenderEngine->settings->fov * (ILLUMINATION_ENGINE_PI / 360)) * 1 / aspectRatio) * (360 / ILLUMINATION_ENGINE_PI);
+    aspectRatio = double((*linkedRenderEngine->settings->currentResolution)[0]) /
+      (*linkedRenderEngine->settings->currentResolution)[1];
+    fov = linkedRenderEngine->settings->fov;
+    horizontalFOV =
+      tanh(tan(linkedRenderEngine->settings->fov * (ILLUMINATION_ENGINE_PI / 360)) * 1 / aspectRatio) *
+      (360 / ILLUMINATION_ENGINE_PI);
 }

--- a/src/GraphicsModule/IECamera.hpp
+++ b/src/GraphicsModule/IECamera.hpp
@@ -13,32 +13,36 @@ class IERenderEngine;
 
 // External dependencies
 #define GLM_FORCE_RADIANS
-#include <glm/glm.hpp>
+
 #include <glm/ext/matrix_transform.hpp>
+#include <glm/glm.hpp>
 
 // System dependencies
 #include <cmath>
 
 class IECamera {
 public:
-	void create(IERenderEngine *engineLink);
+    void create(IERenderEngine *engineLink);
 
-	void update();
+    void update();
 
-	void updateSettings();
+    void updateSettings();
 
-	IERenderEngine *linkedRenderEngine{};
-	float yaw{90};
-	float pitch{0};
-	double aspectRatio{16.0 / 9};
-	double fov{90};
-	double horizontalFOV{tanh(tan(fov * (ILLUMINATION_ENGINE_PI / 360)) * 1 / aspectRatio) * (360 / ILLUMINATION_ENGINE_PI)};
-	glm::vec3 front{glm::normalize(glm::vec3{cos(glm::radians(yaw)) * cos(glm::radians(pitch)), sin(glm::radians(yaw)) * cos(glm::radians(pitch)),
-											 sin(glm::radians(pitch))})};
-	glm::vec3 up{0, 0, 1};
-	glm::vec3 right{glm::cross(front, up)};
-	glm::mat4 viewMatrix{glm::lookAt(position, position + front, up)};
-	glm::mat4 projectionMatrix{};
-	glm::vec3 position{};
-	float speed{1};
+    IERenderEngine *linkedRenderEngine{};
+    float           yaw{90};
+    float           pitch{0};
+    double          aspectRatio{16.0 / 9};
+    double          fov{90};
+    double          horizontalFOV{
+      tanh(tan(fov * (ILLUMINATION_ENGINE_PI / 360)) * 1 / aspectRatio) * (360 / ILLUMINATION_ENGINE_PI)};
+    glm::vec3 front{glm::normalize(glm::vec3{
+      cos(glm::radians(yaw)) * cos(glm::radians(pitch)),
+      sin(glm::radians(yaw)) * cos(glm::radians(pitch)),
+      sin(glm::radians(pitch))})};
+    glm::vec3 up{0, 0, 1};
+    glm::vec3 right{glm::cross(front, up)};
+    glm::mat4 viewMatrix{glm::lookAt(position, position + front, up)};
+    glm::mat4 projectionMatrix{};
+    glm::vec3 position{};
+    float     speed{1};
 };

--- a/src/GraphicsModule/IEMonitor.hpp
+++ b/src/GraphicsModule/IEMonitor.hpp
@@ -5,8 +5,8 @@
 #include <cstdint>
 
 class IEMonitor {
-	uint16_t refreshRate{};
-	uint16_t resolution[2]{};
-	uint16_t currentResolution[2]{};
-	uint16_t position[2]{};
+    uint16_t refreshRate{};
+    uint16_t resolution[2]{};
+    uint16_t currentResolution[2]{};
+    uint16_t position[2]{};
 };

--- a/src/GraphicsModule/IERenderEngine.cpp
+++ b/src/GraphicsModule/IERenderEngine.cpp
@@ -5,15 +5,15 @@
 #include "GraphicsModule/Renderable/IERenderable.hpp"
 
 /* Include dependencies from Core. */
-#include "Core/LogModule/IELogger.hpp"
 #include "Core/AssetModule/IEAsset.hpp"
 #include "Core/IEWindowUser.hpp"
+#include "Core/LogModule/IELogger.hpp"
 
 /* Include external dependencies. */
 #define GLEW_IMPLEMENTATION
-#include <include/GL/glew.h>
 
 #include <GLFW/glfw3.h>
+#include <include/GL/glew.h>
 
 #define VMA_IMPLEMENTATION
 
@@ -26,859 +26,800 @@
 /* Include system dependencies. */
 #include <filesystem>
 
-
 vkb::Instance IERenderEngine::createVulkanInstance() {
-	vkb::InstanceBuilder builder;
+    vkb::InstanceBuilder builder;
 
-	// Set engine properties
-	builder.set_engine_name(ILLUMINATION_ENGINE_NAME);
-	builder.set_engine_version(ILLUMINATION_ENGINE_VERSION_MAJOR, ILLUMINATION_ENGINE_VERSION_MINOR, ILLUMINATION_ENGINE_VERSION_PATCH);
+    // Set engine properties
+    builder.set_engine_name(ILLUMINATION_ENGINE_NAME);
+    builder.set_engine_version(
+      ILLUMINATION_ENGINE_VERSION_MAJOR,
+      ILLUMINATION_ENGINE_VERSION_MINOR,
+      ILLUMINATION_ENGINE_VERSION_PATCH
+    );
 
-	// Set application properties
-	builder.set_app_name(settings->applicationName.c_str());
-	builder.set_app_version(settings->applicationVersion.number);
+    // Set application properties
+    builder.set_app_name(settings->applicationName.c_str());
+    builder.set_app_version(settings->applicationVersion.number);
 
-	// If debugging and components are available, add validation layers and a debug messenger
-	#ifndef NDEBUG
-	if (systemInfo->validation_layers_available) {
-		builder.request_validation_layers();
-	}
-	if (systemInfo->debug_utils_available) {
-		builder.use_default_debug_messenger();  /**@todo Make a custom messenger that uses the logging system.*/
-	}
-	#endif
+    // If debugging and components are available, add validation layers and a debug messenger
+#ifndef NDEBUG
+    if (systemInfo->validation_layers_available) builder.request_validation_layers();
+    if (systemInfo->debug_utils_available)
+        builder.use_default_debug_messenger(); /**@todo Make a custom messenger that uses the logging system.*/
+#endif
 
-	// Build the instance and check for errors.
-	vkb::detail::Result<vkb::Instance> instanceBuilder = builder.build();
-	if (!instanceBuilder) {
-		settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create Vulkan instance. Error: " + instanceBuilder.error().message());
-	}
-	deletionQueue.insert(deletionQueue.begin(), [&] { vkb::destroy_instance(instance); });
-	instance = instanceBuilder.value();
-	return instance;
+    // Build the instance and check for errors.
+    vkb::Result<vkb::Instance> instanceBuilder = builder.build();
+    if (!instanceBuilder) {
+        settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to create Vulkan instance. Error: " + instanceBuilder.error().message()
+        );
+    }
+    deletionQueue.insert(deletionQueue.begin(), [&] { vkb::destroy_instance(instance); });
+    instance = instanceBuilder.value();
+    return instance;
 }
 
 GLFWwindow *IERenderEngine::createWindow() const {
-	GLFWwindow *pWindow = glfwCreateWindow(settings->defaultResolution[0], settings->defaultResolution[1], settings->applicationName.c_str(), nullptr, nullptr);
-	if (pWindow == nullptr) {
-		const char *description;
-		int code = glfwGetError(&description);
-		settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Failed to create window! Error: " + std::to_string(code) + " " + description);
-	}
-	return pWindow;
+    GLFWwindow *pWindow = glfwCreateWindow(
+      settings->defaultResolution[0],
+      settings->defaultResolution[1],
+      settings->applicationName.c_str(),
+      nullptr,
+      nullptr
+    );
+    if (pWindow == nullptr) {
+        const char *description;
+        int         code = glfwGetError(&description);
+        settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Failed to create window! Error: " + std::to_string(code) + " " + description
+        );
+    }
+    return pWindow;
 }
 
 void IERenderEngine::setWindowIcons(const std::filesystem::path &path) const {
-	int width;
-	int height;
-	int channels;
-	std::vector<GLFWimage> icons{};
+    int                    width;
+    int                    height;
+    int                    channels;
+    std::vector<GLFWimage> icons{};
 
-	// iterate over all files and directories within path recursively
-	for (const std::filesystem::directory_entry &file: std::filesystem::recursive_directory_iterator(path)) {
-		stbi_uc *pixels = stbi_load(file.path().string().c_str(), &width, &height, &channels,
-									STBI_rgb_alpha);  // Load image from disk
-		if (pixels == nullptr) {
-			settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-								 "Failed to load icon " + file.path().generic_string() + ". Is this file an image?");
-		}
-		icons.push_back(GLFWimage{.width=width, .height=height, .pixels=pixels});  // Generate image
-	}
-	glfwSetWindowIcon(window, static_cast<int>(icons.size()), icons.data());  // Set icons
-	for (GLFWimage icon: icons) {
-		stbi_image_free(icon.pixels);  // Free all pixel data
-	}
+    // iterate over all files and directories within path recursively
+    for (const std::filesystem::directory_entry &file : std::filesystem::recursive_directory_iterator(path)) {
+        stbi_uc *pixels = stbi_load(
+          file.path().string().c_str(),
+          &width,
+          &height,
+          &channels,
+          STBI_rgb_alpha
+        );  // Load image from disk
+        if (pixels == nullptr) {
+            settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+              "Failed to load icon " + file.path().generic_string() + ". Is this file an image?"
+            );
+        }
+        icons.push_back(GLFWimage{.width = width, .height = height, .pixels = pixels});  // Generate image
+    }
+    glfwSetWindowIcon(window, static_cast<int>(icons.size()), icons.data());  // Set icons
+    for (GLFWimage icon : icons) stbi_image_free(icon.pixels);                // Free all pixel data
 }
 
 VkSurfaceKHR IERenderEngine::createWindowSurface() {
-	if (glfwCreateWindowSurface(instance.instance, window, nullptr, &surface) != VK_SUCCESS) {
-		settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create window surface!");
-	}
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		vkb::destroy_surface(instance.instance, surface);
-	});
-	return surface;
+    if (glfwCreateWindowSurface(instance.instance, window, nullptr, &surface) != VK_SUCCESS)
+        settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create window surface!");
+    deletionQueue.insert(deletionQueue.begin(), [&] { vkb::destroy_surface(instance.instance, surface); });
+    return surface;
 }
 
-vkb::Device IERenderEngine::setUpDevice(std::vector<std::vector<const char *>> *desiredExtensions, void *desiredExtensionFeatures) {
-	vkb::PhysicalDeviceSelector selector{instance};
-	// Note: The physical device selection stage is used to add extensions while the logical device building stage is used to add extension features.
+vkb::Device IERenderEngine::setUpDevice(
+  std::vector<std::vector<const char *>> *desiredExtensions,
+  void                                   *desiredExtensionFeatures
+) {
+    vkb::PhysicalDeviceSelector selector{instance};
+    // Note: The physical device selection stage is used to add extensions while the logical device building stage
+    // is used to add extension features.
 
-	// Add desired extensions if any are listed.
-	if (desiredExtensions != nullptr && !desiredExtensions->empty()) {
-		selector.add_desired_extensions(*desiredExtensions->data());
-	}
+    // Add desired extensions if any are listed.
+    if (desiredExtensions != nullptr && !desiredExtensions->empty())
+        selector.add_desired_extensions(*desiredExtensions->data());
 
-	selector.prefer_gpu_device_type(vkb::PreferredDeviceType::discrete);
+    selector.prefer_gpu_device_type(vkb::PreferredDeviceType::discrete);
 
-	// Set surface for physical device.
-	vkb::detail::Result<vkb::PhysicalDevice> physicalDeviceBuilder = selector.set_surface(surface).select();
+    // Set surface for physical device.
+    vkb::Result<vkb::PhysicalDevice> physicalDeviceBuilder = selector.set_surface(surface).select();
 
-	// Prepare to build logical device
-	vkb::DeviceBuilder logicalDeviceBuilder{physicalDeviceBuilder.value()};
+    // Prepare to build logical device
+    vkb::DeviceBuilder logicalDeviceBuilder{physicalDeviceBuilder.value()};
 
-	// Add extension features if any are listed.
-	if (desiredExtensionFeatures != nullptr) {
-		logicalDeviceBuilder.add_pNext(desiredExtensionFeatures);
-	}
+    // Add extension features if any are listed.
+    if (desiredExtensionFeatures != nullptr) logicalDeviceBuilder.add_pNext(desiredExtensionFeatures);
 
-	// Build logical device.
-	vkb::detail::Result<vkb::Device> logicalDevice = logicalDeviceBuilder.build();
-	if (!logicalDevice) {
-		// Failed? Report the error.
-		settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create Vulkan device! Error: " + logicalDevice.error().message());
-	}
+    // Build logical device.
+    vkb::Result<vkb::Device> logicalDevice = logicalDeviceBuilder.build();
+    if (!logicalDevice) {
+        // Failed? Report the error.
+        settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to create Vulkan device! Error: " + logicalDevice.error().message()
+        );
+    }
 
-	// get the device and add its destruction to the deletion queue.
-	device = logicalDevice.value();
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		vkb::destroy_device(device);
-	});
-	return device;
+    // get the device and add its destruction to the deletion queue.
+    device = logicalDevice.value();
+    deletionQueue.insert(deletionQueue.begin(), [&] { vkb::destroy_device(device); });
+    return device;
 }
 
 VmaAllocator IERenderEngine::setUpGPUMemoryAllocator() {
-	VmaAllocatorCreateInfo allocatorInfo{
-			.physicalDevice = device.physical_device.physical_device,
-			.device = device.device,
-			.instance = instance.instance,
-	};
-	if (settings->rayTracing) {
-		allocatorInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
-	}
-//    allocatorInfo.vulkanApiVersion = api.version.number;
-	vmaCreateAllocator(&allocatorInfo, &allocator);
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		vmaDestroyAllocator(allocator);
-	});
-	return allocator;
+    VmaAllocatorCreateInfo allocatorInfo{
+      .physicalDevice = device.physical_device.physical_device,
+      .device         = device.device,
+      .instance       = instance.instance,
+    };
+    if (settings->rayTracing) allocatorInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+    //    allocatorInfo.vulkanApiVersion = api.version.number;
+    vmaCreateAllocator(&allocatorInfo, &allocator);
+    deletionQueue.insert(deletionQueue.begin(), [&] { vmaDestroyAllocator(allocator); });
+    return allocator;
 }
 
 vkb::Swapchain IERenderEngine::createSwapchain(bool useOldSwapchain) {
-	// Create swapchain builder
-	vkb::SwapchainBuilder swapchainBuilder{device};
-	swapchainBuilder.set_desired_present_mode(settings->vSync ? VK_PRESENT_MODE_MAILBOX_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR)
-			.set_desired_extent((*settings->currentResolution)[0], (*settings->currentResolution)[1])
-			.set_desired_format(
-					{VK_FORMAT_B8G8R8A8_SRGB, VK_COLORSPACE_SRGB_NONLINEAR_KHR})  // This may have to change in the event that HDR is to be supported.
-			.set_image_usage_flags(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-	if (useOldSwapchain) {  // Use the old swapchain if it exists and its usage was requested.
-		swapchainBuilder.set_old_swapchain(swapchain);
-	}
-	vkb::detail::Result<vkb::Swapchain> thisSwapchain = swapchainBuilder.build();
-	if (!thisSwapchain) {
-		// Failure! Log it then continue without deleting the old swapchain.
-		settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create swapchain! Error: " + thisSwapchain.error().message());
-	} else {
-		// Success! Delete the old swapchain and images and replace them with the new ones.
-		destroySwapchain();
-		swapchain = thisSwapchain.value();
-		swapchainImageViews = swapchain.get_image_views().value();
-	}
-	return swapchain;
+    // Create swapchain builder
+    vkb::SwapchainBuilder swapchainBuilder{device};
+    swapchainBuilder
+      .set_desired_present_mode(settings->vSync ? VK_PRESENT_MODE_MAILBOX_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR)
+      .set_desired_extent((*settings->currentResolution)[0], (*settings->currentResolution)[1])
+      .set_desired_format({VK_FORMAT_B8G8R8A8_SRGB, VK_COLORSPACE_SRGB_NONLINEAR_KHR}
+      )  // This may have to change in the event that HDR is to be supported.
+      .set_image_usage_flags(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    if (useOldSwapchain)  // Use the old swapchain if it exists and its usage was requested.
+        swapchainBuilder.set_old_swapchain(swapchain);
+    vkb::Result<vkb::Swapchain> thisSwapchain = swapchainBuilder.build();
+    if (!thisSwapchain) {
+        // Failure! Log it then continue without deleting the old swapchain.
+        settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to create swapchain! Error: " + thisSwapchain.error().message()
+        );
+    } else {
+        // Success! Delete the old swapchain and images and replace them with the new ones.
+        destroySwapchain();
+        swapchain           = thisSwapchain.value();
+        swapchainImageViews = swapchain.get_image_views().value();
+    }
+    return swapchain;
 }
 
 void IERenderEngine::createSyncObjects() {
-	// Avoid potential major issues when threading by waiting for the device to stop using any sync objects
-	vkDeviceWaitIdle(device.device);
+    // Avoid potential major issues when threading by waiting for the device to stop using any sync objects
+    vkDeviceWaitIdle(device.device);
 
-	// Prepare for creation
-	VkSemaphoreCreateInfo semaphoreCreateInfo{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
-	VkFenceCreateInfo fenceCreateInfo{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, VK_FENCE_CREATE_SIGNALED_BIT};
+    // Prepare for creation
+    VkSemaphoreCreateInfo semaphoreCreateInfo{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+    VkFenceCreateInfo fenceCreateInfo{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, VK_FENCE_CREATE_SIGNALED_BIT};
 
-	// Ensure that the vectors have the appropriate size as to avoid errors in the next step.
-	imageAvailableSemaphores.resize(swapchain.image_count);
-	renderFinishedSemaphores.resize(swapchain.image_count);
-	inFlightFences.resize(swapchain.image_count);
-	imagesInFlight.resize(swapchain.image_count);
+    // Ensure that the vectors have the appropriate size as to avoid errors in the next step.
+    imageAvailableSemaphores.resize(swapchain.image_count);
+    renderFinishedSemaphores.resize(swapchain.image_count);
+    inFlightFences.resize(swapchain.image_count);
+    imagesInFlight.resize(swapchain.image_count);
 
-	// Create all the semaphores and fences.
-	for (uint32_t i = 0; i < swapchain.image_count; ++i) {
-		vkCreateSemaphore(device.device, &semaphoreCreateInfo, nullptr, &imageAvailableSemaphores[i]);
-		vkCreateSemaphore(device.device, &semaphoreCreateInfo, nullptr, &renderFinishedSemaphores[i]);
-		vkCreateFence(device.device, &fenceCreateInfo, nullptr, &inFlightFences[i]);
-	}
+    // Create all the semaphores and fences.
+    for (uint32_t i = 0; i < swapchain.image_count; ++i) {
+        vkCreateSemaphore(device.device, &semaphoreCreateInfo, nullptr, &imageAvailableSemaphores[i]);
+        vkCreateSemaphore(device.device, &semaphoreCreateInfo, nullptr, &renderFinishedSemaphores[i]);
+        vkCreateFence(device.device, &fenceCreateInfo, nullptr, &inFlightFences[i]);
+    }
 }
 
 void IERenderEngine::createCommandPools() {
-	IECommandPool::CreateInfo commandPoolCreateInfo{};
-	vkb::detail::Result<VkQueue> graphicsQueueDetails = device.get_queue(vkb::QueueType::graphics);
-	if (graphicsQueueDetails.has_value()) {
-		graphicsQueue = graphicsQueueDetails.value();
-	}
-	if (graphicsQueue != nullptr) {
-		graphicsCommandPool = std::make_shared<IECommandPool>();
-		commandPoolCreateInfo.commandQueue = vkb::QueueType::graphics;
-		graphicsCommandPool->create(this, &commandPoolCreateInfo);
-	}
-	vkb::detail::Result<VkQueue> presentQueueDetails = device.get_queue(vkb::QueueType::present);
-	if (presentQueueDetails.has_value()) {
-		presentQueue = presentQueueDetails.value();
-	}
-	if (presentQueue != nullptr) {
-		presentCommandPool = std::make_shared<IECommandPool>();
-		commandPoolCreateInfo.commandQueue = vkb::QueueType::present;
-		presentCommandPool->create(this, &commandPoolCreateInfo);
-	}
-	vkb::detail::Result<VkQueue> transferQueueDetails = device.get_queue(vkb::QueueType::transfer);
-	if (transferQueueDetails.has_value()) {
-		transferQueue = transferQueueDetails.value();
-	}
-	if (transferQueue != nullptr) {
-		transferCommandPool = std::make_shared<IECommandPool>();
-		commandPoolCreateInfo.commandQueue = vkb::QueueType::transfer;
-		transferCommandPool->create(this, &commandPoolCreateInfo);
-	}
-	vkb::detail::Result<VkQueue> computeQueueDetails = device.get_queue(vkb::QueueType::compute);
-	if (computeQueueDetails.has_value()) {
-		computeQueue = computeQueueDetails.value();
-	}
-	if (computeQueue != nullptr) {
-		computeCommandPool = std::make_shared<IECommandPool>();
-		commandPoolCreateInfo.commandQueue = vkb::QueueType::compute;
-		computeCommandPool->create(this, &commandPoolCreateInfo);
-	}
+    IECommandPool::CreateInfo commandPoolCreateInfo{};
+    vkb::Result<VkQueue>      graphicsQueueDetails = device.get_queue(vkb::QueueType::graphics);
+    if (graphicsQueueDetails.has_value()) graphicsQueue = graphicsQueueDetails.value();
+    if (graphicsQueue != nullptr) {
+        graphicsCommandPool                = std::make_shared<IECommandPool>();
+        commandPoolCreateInfo.commandQueue = vkb::QueueType::graphics;
+        graphicsCommandPool->create(this, &commandPoolCreateInfo);
+    }
+    vkb::Result<VkQueue> presentQueueDetails = device.get_queue(vkb::QueueType::present);
+    if (presentQueueDetails.has_value()) presentQueue = presentQueueDetails.value();
+    if (presentQueue != nullptr) {
+        presentCommandPool                 = std::make_shared<IECommandPool>();
+        commandPoolCreateInfo.commandQueue = vkb::QueueType::present;
+        presentCommandPool->create(this, &commandPoolCreateInfo);
+    }
+    vkb::Result<VkQueue> transferQueueDetails = device.get_queue(vkb::QueueType::transfer);
+    if (transferQueueDetails.has_value()) transferQueue = transferQueueDetails.value();
+    if (transferQueue != nullptr) {
+        transferCommandPool                = std::make_shared<IECommandPool>();
+        commandPoolCreateInfo.commandQueue = vkb::QueueType::transfer;
+        transferCommandPool->create(this, &commandPoolCreateInfo);
+    }
+    vkb::Result<VkQueue> computeQueueDetails = device.get_queue(vkb::QueueType::compute);
+    if (computeQueueDetails.has_value()) computeQueue = computeQueueDetails.value();
+    if (computeQueue != nullptr) {
+        computeCommandPool                 = std::make_shared<IECommandPool>();
+        commandPoolCreateInfo.commandQueue = vkb::QueueType::compute;
+        computeCommandPool->create(this, &commandPoolCreateInfo);
+    }
 }
 
 void IERenderEngine::createRenderPass() {
-	// Create the renderPass
-	renderPass = std::make_shared<IERenderPass>();
-	graphicsCommandPool->prepareCommandBuffers(swapchainImageViews.size());
-	IERenderPass::CreateInfo renderPassCreateInfo{
-			.msaaSamples=1
-	};
-	renderPass->create(this, &renderPassCreateInfo);
+    // Create the renderPass
+    renderPass = std::make_shared<IERenderPass>();
+    graphicsCommandPool->prepareCommandBuffers(swapchainImageViews.size());
+    IERenderPass::CreateInfo renderPassCreateInfo{.msaaSamples = 1};
+    renderPass->create(this, &renderPassCreateInfo);
 }
 
 void IERenderEngine::setAPI(const IEAPI &API) {
-	IERenderable::setAPI(API);
-	IEMesh::setAPI(API);
-	IEMaterial::setAPI(API);
-	IEImage::setAPI(API);
-	IEBuffer::setAPI(API);
-	IEShader::setAPI(API);
-	IEPipeline::setAPI(API);
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_update = &IERenderEngine::_openGLUpdate;
-		_destroy = &IERenderEngine::_openGLDestroy;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_update = &IERenderEngine::_vulkanUpdate;
-		_destroy = &IERenderEngine::_vulkanDestroy;
-	} else {
-		std::cout << "Attempt to set current Graphics API to an invalid API. Valid APIs: Vulkan, OpenGL" << std::endl;
-	}
+    IERenderable::setAPI(API);
+    IEMesh::setAPI(API);
+    IEMaterial::setAPI(API);
+    IEImage::setAPI(API);
+    IEBuffer::setAPI(API);
+    IEShader::setAPI(API);
+    IEPipeline::setAPI(API);
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _update  = &IERenderEngine::_openGLUpdate;
+        _destroy = &IERenderEngine::_openGLDestroy;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _update  = &IERenderEngine::_vulkanUpdate;
+        _destroy = &IERenderEngine::_vulkanDestroy;
+    } else {
+        std::cout << "Attempt to set current Graphics API to an invalid API. Valid APIs: Vulkan, OpenGL"
+                  << std::endl;
+    }
 }
 
 IEAPI *IERenderEngine::autoDetectAPIVersion(const std::string &api) {
-	API = IEAPI{api};
-	API.version = API.getHighestSupportedVersion(this);
-	setAPI(API);
-	return &API;
+    API         = IEAPI{api};
+    API.version = API.getHighestSupportedVersion(this);
+    setAPI(API);
+    return &API;
 }
 
 void IERenderEngine::buildFunctionPointers() {
-	vkGetBufferDeviceAddressKHR = reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vkGetDeviceProcAddr(device.device,
-																										"vkGetBufferDeviceAddressKHR"));
-	vkCmdBuildAccelerationStructuresKHR = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(vkGetDeviceProcAddr(device.device,
-																														"vkCmdBuildAccelerationStructuresKHR"));
-	vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(vkGetDeviceProcAddr(device.device,
-																												  "vkCreateAccelerationStructureKHR"));
-	vkDestroyAccelerationStructureKHR = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(vkGetDeviceProcAddr(device.device,
-																													"vkDestroyAccelerationStructureKHR"));
-	vkGetAccelerationStructureBuildSizesKHR = reinterpret_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(vkGetDeviceProcAddr(device.device,
-																																"vkGetAccelerationStructureBuildSizesKHR"));
-	vkGetAccelerationStructureDeviceAddressKHR = reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(vkGetDeviceProcAddr(device.device,
-																																	  "vkGetAccelerationStructureDeviceAddressKHR"));
-	vkAcquireNextImageKhr = reinterpret_cast<PFN_vkAcquireNextImageKHR>(vkGetDeviceProcAddr(device.device, "vkAcquireNextImageKHR"));
+    vkGetBufferDeviceAddressKHR = reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(
+      vkGetDeviceProcAddr(device.device, "vkGetBufferDeviceAddressKHR")
+    );
+    vkCmdBuildAccelerationStructuresKHR = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(
+      vkGetDeviceProcAddr(device.device, "vkCmdBuildAccelerationStructuresKHR")
+    );
+    vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+      vkGetDeviceProcAddr(device.device, "vkCreateAccelerationStructureKHR")
+    );
+    vkDestroyAccelerationStructureKHR = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(
+      vkGetDeviceProcAddr(device.device, "vkDestroyAccelerationStructureKHR")
+    );
+    vkGetAccelerationStructureBuildSizesKHR = reinterpret_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(
+      vkGetDeviceProcAddr(device.device, "vkGetAccelerationStructureBuildSizesKHR")
+    );
+    vkGetAccelerationStructureDeviceAddressKHR = reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(
+      vkGetDeviceProcAddr(device.device, "vkGetAccelerationStructureDeviceAddressKHR")
+    );
+    vkAcquireNextImageKhr =
+      reinterpret_cast<PFN_vkAcquireNextImageKHR>(vkGetDeviceProcAddr(device.device, "vkAcquireNextImageKHR"));
 }
 
 void IERenderEngine::destroySyncObjects() {
-	for (uint32_t i = 0; i < swapchain.image_count; ++i) {
-		vkDestroySemaphore(device.device, imageAvailableSemaphores[i], nullptr);
-		vkDestroySemaphore(device.device, renderFinishedSemaphores[i], nullptr);
-		vkDestroyFence(device.device, inFlightFences[i], nullptr);
-	}
+    for (uint32_t i = 0; i < swapchain.image_count; ++i) {
+        vkDestroySemaphore(device.device, imageAvailableSemaphores[i], nullptr);
+        vkDestroySemaphore(device.device, renderFinishedSemaphores[i], nullptr);
+        vkDestroyFence(device.device, inFlightFences[i], nullptr);
+    }
 }
 
 void IERenderEngine::destroySwapchain() {
-	swapchain.destroy_image_views(swapchainImageViews);
-	vkb::destroy_swapchain(swapchain);
+    swapchain.destroy_image_views(swapchainImageViews);
+    vkb::destroy_swapchain(swapchain);
 }
 
 void IERenderEngine::destroyCommandPools() {
-	graphicsCommandPool->destroy();
-	presentCommandPool->destroy();
-	transferCommandPool->destroy();
-	computeCommandPool->destroy();
+    graphicsCommandPool->destroy();
+    presentCommandPool->destroy();
+    transferCommandPool->destroy();
+    computeCommandPool->destroy();
 }
 
 IERenderEngine::IERenderEngine(IESettings *settings) {
-	this->settings = settings;
+    this->settings = settings;
 
-	// Create a Vulkan instance
-	createVulkanInstance();
+    // Create a Vulkan instance
+    createVulkanInstance();
 
-	// Initialize GLFW then create and setup window
-	/**@todo Clean up this section of the code as it is still quite messy. Optimally this would be done with a GUI abstraction.*/
-	glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-	window = createWindow();
-	setWindowIcons("res/icons");
-	glfwSetWindowSizeLimits(window, 1, 1, GLFW_DONT_CARE, GLFW_DONT_CARE);
-	glfwGetWindowPos(window, &(*settings->currentPosition)[0], &(*settings->currentPosition)[1]);
-	glfwSetWindowAttrib(window, GLFW_AUTO_ICONIFY, 0);
-	glfwSetFramebufferSizeCallback(window, framebufferResizeCallback);
-	glfwSetWindowPosCallback(window, windowPositionCallback);
-	glfwSetWindowUserPointer(window, this);
+    // Initialize GLFW then create and setup window
+    /**@todo Clean up this section of the code as it is still quite messy. Optimally this would be done with a GUI
+     * abstraction.*/
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    window = createWindow();
+    setWindowIcons("res/icons");
+    glfwSetWindowSizeLimits(window, 1, 1, GLFW_DONT_CARE, GLFW_DONT_CARE);
+    glfwGetWindowPos(window, &(*settings->currentPosition)[0], &(*settings->currentPosition)[1]);
+    glfwSetWindowAttrib(window, GLFW_AUTO_ICONIFY, 0);
+    glfwSetFramebufferSizeCallback(window, framebufferResizeCallback);
+    glfwSetWindowPosCallback(window, windowPositionCallback);
+    glfwSetWindowUserPointer(window, this);
 
-	// Create surface
-	createWindowSurface();
+    // Create surface
+    createWindowSurface();
 
-	// Set up the device
-	std::vector<std::vector<const char *>> extensions{};
-	if (settings->rayTracing) {
-		extensions.push_back(extensionAndFeatureInfo.queryEngineFeatureExtensionRequirements(IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING, &API));
-		/**@todo Find a better way to handle specifying features. Perhaps use a similar method as was used for extensions.*/
-		extensionAndFeatureInfo.accelerationStructureFeatures.accelerationStructure = VK_TRUE;
-		extensionAndFeatureInfo.bufferDeviceAddressFeatures.bufferDeviceAddress = VK_TRUE;
-		extensionAndFeatureInfo.rayQueryFeatures.rayQuery = VK_TRUE;
-		extensionAndFeatureInfo.rayTracingPipelineFeatures.rayTracingPipeline = VK_TRUE;
-	}
-	setUpDevice(&extensions, extensionAndFeatureInfo.pNextHighestFeature);
+    // Set up the device
+    std::vector<std::vector<const char *>> extensions{};
+    if (settings->rayTracing) {
+        extensions.push_back(extensionAndFeatureInfo.queryEngineFeatureExtensionRequirements(
+          IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING,
+          &API
+        ));
+        /**@todo Find a better way to handle specifying features. Perhaps use a similar method as was used for
+         * extensions.*/
+        extensionAndFeatureInfo.accelerationStructureFeatures.accelerationStructure = VK_TRUE;
+        extensionAndFeatureInfo.bufferDeviceAddressFeatures.bufferDeviceAddress     = VK_TRUE;
+        extensionAndFeatureInfo.rayQueryFeatures.rayQuery                           = VK_TRUE;
+        extensionAndFeatureInfo.rayTracingPipelineFeatures.rayTracingPipeline       = VK_TRUE;
+    }
+    setUpDevice(&extensions, extensionAndFeatureInfo.pNextHighestFeature);
 
-	// Get API Version
-	autoDetectAPIVersion(IE_RENDER_ENGINE_API_NAME_VULKAN);
+    // Get API Version
+    autoDetectAPIVersion(IE_RENDER_ENGINE_API_NAME_VULKAN);
 
-	// Build function pointers and generate queues
-	buildFunctionPointers();
+    // Build function pointers and generate queues
+    buildFunctionPointers();
 
-	// Set up GPU Memory allocator
-	setUpGPUMemoryAllocator();
+    // Set up GPU Memory allocator
+    setUpGPUMemoryAllocator();
 
-	// Create swapchain
-	createSwapchain(false);
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		destroySwapchain();
-	});
+    // Create swapchain
+    createSwapchain(false);
+    deletionQueue.insert(deletionQueue.begin(), [&] { destroySwapchain(); });
 
-	// Create sync objects
-	/**@todo Create an abstraction for sync objects if necessary.*/
-	createSyncObjects();
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		destroySyncObjects();
-	});
+    // Create sync objects
+    /**@todo Create an abstraction for sync objects if necessary.*/
+    createSyncObjects();
+    deletionQueue.insert(deletionQueue.begin(), [&] { destroySyncObjects(); });
 
-	// Create command pools
-	createCommandPools();
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		destroyCommandPools();
-	});
+    // Create command pools
+    createCommandPools();
+    deletionQueue.insert(deletionQueue.begin(), [&] { destroyCommandPools(); });
 
-	IEImage::CreateInfo depthImageCreateInfo{
-			.format=VK_FORMAT_D32_SFLOAT_S8_UINT,
-			.layout=VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
-			.usage=VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-			.aspect=VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
-			.allocationUsage=VMA_MEMORY_USAGE_GPU_ONLY,
-			.width=swapchain.extent.width,
-			.height=swapchain.extent.height,
-			.channels=1,
-	};
-	depthImage = std::make_shared<IEImage>(this, &depthImageCreateInfo);
-	depthImage->uploadToVRAM();
+    IEImage::CreateInfo depthImageCreateInfo{
+      .format          = VK_FORMAT_D32_SFLOAT_S8_UINT,
+      .layout          = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+      .usage           = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+      .aspect          = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
+      .allocationUsage = VMA_MEMORY_USAGE_GPU_ONLY,
+      .width           = swapchain.extent.width,
+      .height          = swapchain.extent.height,
+      .channels        = 1,
+    };
+    depthImage = std::make_shared<IEImage>(this, &depthImageCreateInfo);
+    depthImage->uploadToVRAM();
 
-	// Create render pass
-	createRenderPass();
-	deletionQueue.insert(deletionQueue.begin(), [&] {
-		renderPass->destroy();
-	});
+    // Create render pass
+    createRenderPass();
+    deletionQueue.insert(deletionQueue.begin(), [&] { renderPass->destroy(); });
 
-	graphicsCommandPool->index(0)->execute();
-	camera.create(this);
-	settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, device.physical_device.properties.deviceName);
-	settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, API.name + " v" + API.version.name);
+    graphicsCommandPool->index(0)->execute();
+    camera.create(this);
+    settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, device.physical_device.properties.deviceName);
+    settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, API.name + " v" + API.version.name);
 }
 
 void IERenderEngine::addAsset(const std::shared_ptr<IEAsset> &asset) {
-	for (std::shared_ptr<IEAspect> &aspect: asset->aspects) {
-		// If aspect is downcast-able to a renderable
-		if (dynamic_cast<IERenderable *>(aspect.get())) {
-			renderables.push_back(std::dynamic_pointer_cast<IERenderable>(aspect));
-			std::dynamic_pointer_cast<IERenderable>(aspect)->create(this, asset->filename);
-			std::dynamic_pointer_cast<IERenderable>(aspect)->loadFromDiskToRAM();
-			std::dynamic_pointer_cast<IERenderable>(aspect)->loadFromRAMToVRAM();
-		}
-	}
-	if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		graphicsCommandPool->index(0)->execute();
-	}
+    for (std::shared_ptr<IEAspect> &aspect : asset->aspects) {
+        // If aspect is downcast-able to a renderable
+        if (dynamic_cast<IERenderable *>(aspect.get())) {
+            renderables.push_back(std::dynamic_pointer_cast<IERenderable>(aspect));
+            std::dynamic_pointer_cast<IERenderable>(aspect)->create(this, asset->filename);
+            std::dynamic_pointer_cast<IERenderable>(aspect)->loadFromDiskToRAM();
+            std::dynamic_pointer_cast<IERenderable>(aspect)->loadFromRAMToVRAM();
+        }
+    }
+    if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) graphicsCommandPool->index(0)->execute();
 }
 
 void IERenderEngine::handleResolutionChange() {
-	if(API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		createSwapchain();
-		IEImage::CreateInfo depthImageCreateInfo{
-				.format=VK_FORMAT_D32_SFLOAT_S8_UINT,
-				.layout=VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
-				.usage=VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-				.aspect=VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
-				.allocationUsage=VMA_MEMORY_USAGE_GPU_ONLY,
-				.width=swapchain.extent.width,
-				.height=swapchain.extent.height,
-				.channels=1,
-		};
-		depthImage = std::make_shared<IEImage>(this, &depthImageCreateInfo);
-		depthImage->uploadToVRAM();
-		renderPass->destroy();
-		createRenderPass();
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        createSwapchain();
+        IEImage::CreateInfo depthImageCreateInfo{
+          .format          = VK_FORMAT_D32_SFLOAT_S8_UINT,
+          .layout          = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+          .usage           = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+          .aspect          = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
+          .allocationUsage = VMA_MEMORY_USAGE_GPU_ONLY,
+          .width           = swapchain.extent.width,
+          .height          = swapchain.extent.height,
+          .channels        = 1,
+        };
+        depthImage = std::make_shared<IEImage>(this, &depthImageCreateInfo);
+        depthImage->uploadToVRAM();
+        renderPass->destroy();
+        createRenderPass();
+    }
 }
 
 bool IERenderEngine::update() {
-	return _update(*this);
+    return _update(*this);
 }
 
 bool IERenderEngine::_openGLUpdate() {
-	glEnable(GL_DEPTH_TEST);
-	glEnable(GL_FRAMEBUFFER_SRGB);
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-	camera.update();
-	glViewport(0, 0, (*settings->currentResolution)[0], (*settings->currentResolution)[1]);
-	for (const std::weak_ptr<IERenderable> &renderable: renderables) {
-		renderable.lock()->update(0);
-	}
-	glfwSwapBuffers(window);
-	auto currentTime = (float) glfwGetTime();
-	frameTime = currentTime - previousTime;
-	previousTime = currentTime;
-	frameNumber++;
-	return !glfwWindowShouldClose(window);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_FRAMEBUFFER_SRGB);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    camera.update();
+    glViewport(0, 0, (*settings->currentResolution)[0], (*settings->currentResolution)[1]);
+    for (const std::weak_ptr<IERenderable> &renderable : renderables) renderable.lock()->update(0);
+    glfwSwapBuffers(window);
+    auto currentTime = (float) glfwGetTime();
+    frameTime        = currentTime - previousTime;
+    previousTime     = currentTime;
+    frameNumber++;
+    return !glfwWindowShouldClose(window);
 }
 
 bool IERenderEngine::_vulkanUpdate() {
-	if (window == nullptr) {
-		return false;
-	}
-	if (renderables.empty()) {
-		return glfwWindowShouldClose(window) != 1;
-	}
-	vkWaitForFences(device.device, 1, &inFlightFences[currentFrame], VK_TRUE, UINT64_MAX);
-	uint32_t imageIndex{0};
-	VkResult result = vkAcquireNextImageKhr(device.device, swapchain.swapchain, UINT64_MAX, imageAvailableSemaphores[currentFrame], VK_NULL_HANDLE,
-											&imageIndex);
-	if (result != VK_SUCCESS) {
-		handleResolutionChange();
-		return glfwWindowShouldClose(window) != 1;
-	}
-	if (imagesInFlight[imageIndex] != VK_NULL_HANDLE) {
-		vkWaitForFences(device.device, 1, &imagesInFlight[imageIndex], VK_TRUE, UINT64_MAX);
-	}
-	imagesInFlight[imageIndex] = inFlightFences[currentFrame];
-	VkViewport viewport{
-			.x = 0.0F,
-			.y = 0.0F,
-			.width = (float) swapchain.extent.width,
-			.height = (float) swapchain.extent.height,
-			.minDepth = 0.0F,
-			.maxDepth = 1.0F
-	};
-	graphicsCommandPool->index(imageIndex)->recordSetViewport(0, 1, &viewport);
-	VkRect2D scissor{
-			.offset = {0, 0},
-			.extent = swapchain.extent,
-	};
-	graphicsCommandPool->index(imageIndex)->recordSetScissor(0, 1, &scissor);
-	IERenderPassBeginInfo renderPassBeginInfo = renderPass->beginRenderPass(imageIndex);
-	graphicsCommandPool->index(imageIndex)->recordBeginRenderPass(&renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
-	camera.update();
-	for (const std::weak_ptr<IERenderable> &renderable: renderables) {
-		renderable.lock()->update(imageIndex);
-	}
-	graphicsCommandPool->index(imageIndex)->recordEndRenderPass();
-	graphicsCommandPool->index(imageIndex)->execute(imageAvailableSemaphores[currentFrame], renderFinishedSemaphores[currentFrame],
-													inFlightFences[currentFrame]);
-	VkPresentInfoKHR presentInfo{
-			.sType=VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
-			.waitSemaphoreCount=1,
-			.pWaitSemaphores=&renderFinishedSemaphores[currentFrame],
-			.swapchainCount=1,
-			.pSwapchains=&swapchain.swapchain,
-			.pImageIndices=&imageIndex,
-	};
-	graphicsCommandPool->index(imageIndex)->commandPool->commandPoolMutex.lock();
-	result = vkQueuePresentKHR(presentQueue, &presentInfo);
-	graphicsCommandPool->index(imageIndex)->commandPool->commandPoolMutex.unlock();
-	if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR || framebufferResized) {
-		framebufferResized = false;
-		handleResolutionChange();
-	} else if (result != VK_SUCCESS) {
-		throw std::runtime_error("failed to present swapchain image!");
-	}
-	currentFrame = (currentFrame + 1) % (int) swapchain.image_count;
-	if (frameTime > 1.0 / 30.0) {
-		settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-							 "Frame #" + std::to_string(frameNumber) + " took " + std::to_string(frameTime * 1000) + "ms to compute.");
-	}
-	auto currentTime = (float) glfwGetTime();
-	frameTime = currentTime - previousTime;
-	previousTime = currentTime;
-	frameNumber++;
-	return glfwWindowShouldClose(window) != 1;
+    if (window == nullptr) return false;
+    if (renderables.empty()) return glfwWindowShouldClose(window) != 1;
+    vkWaitForFences(device.device, 1, &inFlightFences[currentFrame], VK_TRUE, UINT64_MAX);
+    uint32_t imageIndex{0};
+    VkResult result = vkAcquireNextImageKhr(
+      device.device,
+      swapchain.swapchain,
+      UINT64_MAX,
+      imageAvailableSemaphores[currentFrame],
+      VK_NULL_HANDLE,
+      &imageIndex
+    );
+    if (result != VK_SUCCESS) {
+        handleResolutionChange();
+        return glfwWindowShouldClose(window) != 1;
+    }
+    if (imagesInFlight[imageIndex] != VK_NULL_HANDLE)
+        vkWaitForFences(device.device, 1, &imagesInFlight[imageIndex], VK_TRUE, UINT64_MAX);
+    imagesInFlight[imageIndex] = inFlightFences[currentFrame];
+    VkViewport viewport{
+      .x        = 0.0F,
+      .y        = 0.0F,
+      .width    = (float) swapchain.extent.width,
+      .height   = (float) swapchain.extent.height,
+      .minDepth = 0.0F,
+      .maxDepth = 1.0F};
+    graphicsCommandPool->index(imageIndex)->recordSetViewport(0, 1, &viewport);
+    VkRect2D scissor{
+      .offset = {0, 0},
+      .extent = swapchain.extent,
+    };
+    graphicsCommandPool->index(imageIndex)->recordSetScissor(0, 1, &scissor);
+    IERenderPassBeginInfo renderPassBeginInfo = renderPass->beginRenderPass(imageIndex);
+    graphicsCommandPool->index(imageIndex)
+      ->recordBeginRenderPass(&renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    camera.update();
+    for (const std::weak_ptr<IERenderable> &renderable : renderables) renderable.lock()->update(imageIndex);
+    graphicsCommandPool->index(imageIndex)->recordEndRenderPass();
+    graphicsCommandPool->index(imageIndex)
+      ->execute(
+        imageAvailableSemaphores[currentFrame],
+        renderFinishedSemaphores[currentFrame],
+        inFlightFences[currentFrame]
+      );
+    VkPresentInfoKHR presentInfo{
+      .sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+      .waitSemaphoreCount = 1,
+      .pWaitSemaphores    = &renderFinishedSemaphores[currentFrame],
+      .swapchainCount     = 1,
+      .pSwapchains        = &swapchain.swapchain,
+      .pImageIndices      = &imageIndex,
+    };
+    graphicsCommandPool->index(imageIndex)->commandPool->commandPoolMutex.lock();
+    result = vkQueuePresentKHR(presentQueue, &presentInfo);
+    graphicsCommandPool->index(imageIndex)->commandPool->commandPoolMutex.unlock();
+    if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR || framebufferResized) {
+        framebufferResized = false;
+        handleResolutionChange();
+    } else if (result != VK_SUCCESS) {
+        throw std::runtime_error("failed to present swapchain image!");
+    }
+    currentFrame = (currentFrame + 1) % (int) swapchain.image_count;
+    if (frameTime > 1.0 / 30.0) {
+        settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Frame #" + std::to_string(frameNumber) + " took " + std::to_string(frameTime * 1000) + "ms to compute."
+        );
+    }
+    auto currentTime = (float) glfwGetTime();
+    frameTime        = currentTime - previousTime;
+    previousTime     = currentTime;
+    frameNumber++;
+    return glfwWindowShouldClose(window) != 1;
 }
 
 void IERenderEngine::toggleFullscreen() {
-	settings->fullscreen ^= true;
-	if (settings->fullscreen) {
-		int monitorCount{};
-		int windowX{};
-		int windowY{};
-		int windowWidth{};
-		int windowHeight{};
-		int monitorX{};
-		int monitorY{};
-		int monitorWidth;
-		int monitorHeight;
-		int bestMonitorWidth{};
-		int bestMonitorHeight{};
-		int bestMonitorRefreshRate{};
-		int overlap;
-		int bestOverlap{0};
-		GLFWmonitor **monitors;
-		const GLFWvidmode *mode;
-		glfwGetWindowPos(window, &windowX, &windowY);
-		glfwGetWindowSize(window, &windowWidth, &windowHeight);
-		monitors = glfwGetMonitors(&monitorCount);
-		for (int i = 0; i < monitorCount; ++i) {
-			mode = glfwGetVideoMode(monitors[i]);
-			glfwGetMonitorPos(monitors[i], &monitorX, &monitorY);
-			monitorWidth = mode->width;
-			monitorHeight = mode->height;
-			overlap = std::max(0, std::min(windowX + windowWidth, monitorX + monitorWidth) - std::max(windowX, monitorX)) *
-					  std::max(0, std::min(windowY + windowHeight, monitorY + monitorHeight) - std::max(windowY, monitorY));
-			if (bestOverlap < overlap) {
-				bestOverlap = overlap;
-				monitor = monitors[i];
-				bestMonitorWidth = monitorWidth;
-				bestMonitorHeight = monitorHeight;
-				bestMonitorRefreshRate = mode->refreshRate;
-			}
-		}
-		settings->refreshRate = bestMonitorRefreshRate;
-		settings->currentResolution = &settings->fullscreenResolution;
-		*settings->currentResolution = {bestMonitorWidth, bestMonitorHeight};
-		glfwGetWindowPos(window, &(*settings->currentPosition)[0], &(*settings->currentPosition)[1]);
-		settings->currentPosition = &settings->fullscreenPosition;
-	} else {
-		monitor = nullptr;
-		settings->currentResolution = &settings->windowedResolution;
-		settings->currentPosition = &settings->windowedPosition;
-	}
-	glfwSetWindowMonitor(window, monitor, (*settings->currentPosition)[0], (*settings->currentPosition)[1], (*settings->currentResolution)[0],
-						 (*settings->currentResolution)[1], settings->refreshRate);
-	handleResolutionChange();
-	glfwSetWindowTitle(window, settings->applicationName.c_str());
+    settings->fullscreen ^= true;
+    if (settings->fullscreen) {
+        int                monitorCount{};
+        int                windowX{};
+        int                windowY{};
+        int                windowWidth{};
+        int                windowHeight{};
+        int                monitorX{};
+        int                monitorY{};
+        int                monitorWidth;
+        int                monitorHeight;
+        int                bestMonitorWidth{};
+        int                bestMonitorHeight{};
+        int                bestMonitorRefreshRate{};
+        int                overlap;
+        int                bestOverlap{0};
+        GLFWmonitor      **monitors;
+        const GLFWvidmode *mode;
+        glfwGetWindowPos(window, &windowX, &windowY);
+        glfwGetWindowSize(window, &windowWidth, &windowHeight);
+        monitors = glfwGetMonitors(&monitorCount);
+        for (int i = 0; i < monitorCount; ++i) {
+            mode = glfwGetVideoMode(monitors[i]);
+            glfwGetMonitorPos(monitors[i], &monitorX, &monitorY);
+            monitorWidth  = mode->width;
+            monitorHeight = mode->height;
+            overlap =
+              std::max(0, std::min(windowX + windowWidth, monitorX + monitorWidth) - std::max(windowX, monitorX)) *
+              std::max(
+                0,
+                std::min(windowY + windowHeight, monitorY + monitorHeight) - std::max(windowY, monitorY)
+              );
+            if (bestOverlap < overlap) {
+                bestOverlap            = overlap;
+                monitor                = monitors[i];
+                bestMonitorWidth       = monitorWidth;
+                bestMonitorHeight      = monitorHeight;
+                bestMonitorRefreshRate = mode->refreshRate;
+            }
+        }
+        settings->refreshRate        = bestMonitorRefreshRate;
+        settings->currentResolution  = &settings->fullscreenResolution;
+        *settings->currentResolution = {bestMonitorWidth, bestMonitorHeight};
+        glfwGetWindowPos(window, &(*settings->currentPosition)[0], &(*settings->currentPosition)[1]);
+        settings->currentPosition = &settings->fullscreenPosition;
+    } else {
+        monitor                     = nullptr;
+        settings->currentResolution = &settings->windowedResolution;
+        settings->currentPosition   = &settings->windowedPosition;
+    }
+    glfwSetWindowMonitor(
+      window,
+      monitor,
+      (*settings->currentPosition)[0],
+      (*settings->currentPosition)[1],
+      (*settings->currentResolution)[0],
+      (*settings->currentResolution)[1],
+      settings->refreshRate
+    );
+    handleResolutionChange();
+    glfwSetWindowTitle(window, settings->applicationName.c_str());
 }
 
 void IERenderEngine::_vulkanDestroy() {
-	for (const std::shared_ptr<IECommandBuffer> &commandBuffer: graphicsCommandPool->commandBuffers) {
-		commandBuffer->wait();
-	}
-	destroySyncObjects();
-	destroySwapchain();
-	for (std::function<void()> &function: renderableDeletionQueue) {
-		function();
-	}
-	for (std::function<void()> &function: recreationDeletionQueue) {
-		function();
-	}
-	recreationDeletionQueue.clear();
-	for (std::function<void()> &function: fullRecreationDeletionQueue) {
-		function();
-	}
-	fullRecreationDeletionQueue.clear();
+    for (const std::shared_ptr<IECommandBuffer> &commandBuffer : graphicsCommandPool->commandBuffers)
+        commandBuffer->wait();
+    destroySyncObjects();
+    destroySwapchain();
+    for (std::function<void()> &function : renderableDeletionQueue) function();
+    for (std::function<void()> &function : recreationDeletionQueue) function();
+    recreationDeletionQueue.clear();
+    for (std::function<void()> &function : fullRecreationDeletionQueue) function();
+    fullRecreationDeletionQueue.clear();
 }
 
 IERenderEngine::~IERenderEngine() {
-	destroy();
+    destroy();
 }
 
 void IERenderEngine::windowPositionCallback(GLFWwindow *pWindow, int x, int y) {
-	std::shared_ptr<IERenderEngine> renderEngine = (std::shared_ptr<IERenderEngine>) ((IEWindowUser *) glfwGetWindowUserPointer(pWindow))->renderEngine;
-	*renderEngine->settings->currentPosition = {x, y};
+    std::shared_ptr<IERenderEngine> renderEngine =
+      (std::shared_ptr<IERenderEngine>) ((IEWindowUser *) glfwGetWindowUserPointer(pWindow))->renderEngine;
+    *renderEngine->settings->currentPosition = {x, y};
 }
 
 void IERenderEngine::framebufferResizeCallback(GLFWwindow *pWindow, int width, int height) {
-	std::shared_ptr<IERenderEngine> renderEngine = (std::shared_ptr<IERenderEngine>) ((IEWindowUser *) glfwGetWindowUserPointer(pWindow))->renderEngine;
-	*renderEngine->settings->currentResolution = {width, height};
-	renderEngine->framebufferResized = true;
+    std::shared_ptr<IERenderEngine> renderEngine =
+      (std::shared_ptr<IERenderEngine>) ((IEWindowUser *) glfwGetWindowUserPointer(pWindow))->renderEngine;
+    *renderEngine->settings->currentResolution = {width, height};
+    renderEngine->framebufferResized           = true;
 }
 
 std::string IERenderEngine::translateVkResultCodes(VkResult result) {
-	switch (result) {
-		case VK_SUCCESS:
-			return "VK_SUCCESS";
-		case VK_NOT_READY:
-			return "VK_NOT_READY";
-		case VK_TIMEOUT:
-			return "VK_TIMEOUT";
-		case VK_EVENT_SET:
-			return "VK_EVENT_SET";
-		case VK_EVENT_RESET:
-			return "VK_EVENT_RESET";
-		case VK_INCOMPLETE:
-			return "VK_INCOMPLETE";
-		case VK_ERROR_OUT_OF_HOST_MEMORY:
-			return "VK_ERROR_OUT_OF_HOST_MEMORY";
-		case VK_ERROR_OUT_OF_DEVICE_MEMORY:
-			return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
-		case VK_ERROR_INITIALIZATION_FAILED:
-			return "VK_ERROR_INITIALIZATION_FAILED";
-		case VK_ERROR_DEVICE_LOST:
-			return "VK_ERROR_DEVICE_LOST";
-		case VK_ERROR_MEMORY_MAP_FAILED:
-			return "VK_ERROR_MEMORY_MAP_FAILED";
-		case VK_ERROR_LAYER_NOT_PRESENT:
-			return "VK_ERROR_LAYER_NOT_PRESENT";
-		case VK_ERROR_EXTENSION_NOT_PRESENT:
-			return "VK_ERROR_EXTENSION_NOT_PRESENT";
-		case VK_ERROR_FEATURE_NOT_PRESENT:
-			return "VK_ERROR_FEATURE_NOT_PRESENT";
-		case VK_ERROR_INCOMPATIBLE_DRIVER:
-			return "VK_ERROR_INCOMPATIBLE_DRIVER";
-		case VK_ERROR_TOO_MANY_OBJECTS:
-			return "VK_ERROR_TOO_MANY_OBJECTS";
-		case VK_ERROR_FORMAT_NOT_SUPPORTED:
-			return "VK_ERROR_FORMAT_NOT_SUPPORTED";
-		case VK_ERROR_FRAGMENTED_POOL:
-			return "VK_ERROR_FRAGMENTED_POOL";
-		case VK_ERROR_UNKNOWN:
-			return "VK_ERROR_UNKNOWN";
-		case VK_ERROR_OUT_OF_POOL_MEMORY:
-			return "VK_ERROR_OUT_OF_POOL_MEMORY";
-		case VK_ERROR_INVALID_EXTERNAL_HANDLE:
-			return "VK_ERROR_INVALID_EXTERNAL_HANDLE";
-		case VK_ERROR_FRAGMENTATION:
-			return "VK_ERROR_FRAGMENTATION";
-		case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS:
-			return "VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS";
-		case VK_PIPELINE_COMPILE_REQUIRED:
-			return "VK_PIPELINE_COMPILE_REQUIRED";
-		case VK_ERROR_SURFACE_LOST_KHR:
-			return "VK_ERROR_SURFACE_LOST_KHR";
-		case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
-			return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
-		case VK_SUBOPTIMAL_KHR:
-			return "VK_SUBOPTIMAL_KHR";
-		case VK_ERROR_OUT_OF_DATE_KHR:
-			return "VK_ERROR_OUT_OF_DATE_KHR";
-		case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
-			return "VK_ERROR_INCOMPATIBLE_DISPLAY_KHR";
-		case VK_ERROR_VALIDATION_FAILED_EXT:
-			return "VK_ERROR_VALIDATION_FAILED_EXT";
-		case VK_ERROR_INVALID_SHADER_NV:
-			return "VK_ERROR_INVALID_SHADER_NV";
-		case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT:
-			return "VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT";
-		case VK_ERROR_NOT_PERMITTED_KHR:
-			return "VK_ERROR_NOT_PERMITTED_KHR";
-		case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
-			return "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT";
-		case VK_THREAD_IDLE_KHR:
-			return "VK_THREAD_IDLE_KHR";
-		case VK_THREAD_DONE_KHR:
-			return "VK_THREAD_DONE_KHR";
-		case VK_OPERATION_DEFERRED_KHR:
-			return "VK_OPERATION_DEFERRED_KHR";
-		case VK_OPERATION_NOT_DEFERRED_KHR:
-			return "VK_OPERATION_NOT_DEFERRED_KHR";
-		case VK_RESULT_MAX_ENUM:
-			return "VK_RESULT_MAX_ENUM";
-		default:
-			return "VK_ERROR_UNKNOWN";
-	}
+    switch (result) {
+        case VK_SUCCESS: return "VK_SUCCESS";
+        case VK_NOT_READY: return "VK_NOT_READY";
+        case VK_TIMEOUT: return "VK_TIMEOUT";
+        case VK_EVENT_SET: return "VK_EVENT_SET";
+        case VK_EVENT_RESET: return "VK_EVENT_RESET";
+        case VK_INCOMPLETE: return "VK_INCOMPLETE";
+        case VK_ERROR_OUT_OF_HOST_MEMORY: return "VK_ERROR_OUT_OF_HOST_MEMORY";
+        case VK_ERROR_OUT_OF_DEVICE_MEMORY: return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+        case VK_ERROR_INITIALIZATION_FAILED: return "VK_ERROR_INITIALIZATION_FAILED";
+        case VK_ERROR_DEVICE_LOST: return "VK_ERROR_DEVICE_LOST";
+        case VK_ERROR_MEMORY_MAP_FAILED: return "VK_ERROR_MEMORY_MAP_FAILED";
+        case VK_ERROR_LAYER_NOT_PRESENT: return "VK_ERROR_LAYER_NOT_PRESENT";
+        case VK_ERROR_EXTENSION_NOT_PRESENT: return "VK_ERROR_EXTENSION_NOT_PRESENT";
+        case VK_ERROR_FEATURE_NOT_PRESENT: return "VK_ERROR_FEATURE_NOT_PRESENT";
+        case VK_ERROR_INCOMPATIBLE_DRIVER: return "VK_ERROR_INCOMPATIBLE_DRIVER";
+        case VK_ERROR_TOO_MANY_OBJECTS: return "VK_ERROR_TOO_MANY_OBJECTS";
+        case VK_ERROR_FORMAT_NOT_SUPPORTED: return "VK_ERROR_FORMAT_NOT_SUPPORTED";
+        case VK_ERROR_FRAGMENTED_POOL: return "VK_ERROR_FRAGMENTED_POOL";
+        case VK_ERROR_UNKNOWN: return "VK_ERROR_UNKNOWN";
+        case VK_ERROR_OUT_OF_POOL_MEMORY: return "VK_ERROR_OUT_OF_POOL_MEMORY";
+        case VK_ERROR_INVALID_EXTERNAL_HANDLE: return "VK_ERROR_INVALID_EXTERNAL_HANDLE";
+        case VK_ERROR_FRAGMENTATION: return "VK_ERROR_FRAGMENTATION";
+        case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS: return "VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS";
+        case VK_PIPELINE_COMPILE_REQUIRED: return "VK_PIPELINE_COMPILE_REQUIRED";
+        case VK_ERROR_SURFACE_LOST_KHR: return "VK_ERROR_SURFACE_LOST_KHR";
+        case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR: return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+        case VK_SUBOPTIMAL_KHR: return "VK_SUBOPTIMAL_KHR";
+        case VK_ERROR_OUT_OF_DATE_KHR: return "VK_ERROR_OUT_OF_DATE_KHR";
+        case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR: return "VK_ERROR_INCOMPATIBLE_DISPLAY_KHR";
+        case VK_ERROR_VALIDATION_FAILED_EXT: return "VK_ERROR_VALIDATION_FAILED_EXT";
+        case VK_ERROR_INVALID_SHADER_NV: return "VK_ERROR_INVALID_SHADER_NV";
+        case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT:
+            return "VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT";
+        case VK_ERROR_NOT_PERMITTED_KHR: return "VK_ERROR_NOT_PERMITTED_KHR";
+        case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT: return "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT";
+        case VK_THREAD_IDLE_KHR: return "VK_THREAD_IDLE_KHR";
+        case VK_THREAD_DONE_KHR: return "VK_THREAD_DONE_KHR";
+        case VK_OPERATION_DEFERRED_KHR: return "VK_OPERATION_DEFERRED_KHR";
+        case VK_OPERATION_NOT_DEFERRED_KHR: return "VK_OPERATION_NOT_DEFERRED_KHR";
+        case VK_RESULT_MAX_ENUM: return "VK_RESULT_MAX_ENUM";
+        default: return "VK_ERROR_UNKNOWN";
+    }
 }
 
 bool IERenderEngine::ExtensionAndFeatureInfo::queryFeatureSupport(const std::string &feature) {
-	return (this->*extensionAndFeatureSupportQueries[feature])();
+    return (this->*extensionAndFeatureSupportQueries[feature])();
 }
 
 bool IERenderEngine::ExtensionAndFeatureInfo::queryExtensionSupport(const std::string &extension) {
-	return std::find(supportedExtensions.begin(), supportedExtensions.end(), extension) != supportedExtensions.end();
+    return std::find(supportedExtensions.begin(), supportedExtensions.end(), extension) !=
+      supportedExtensions.end();
 }
 
-std::vector<const char *>
-IERenderEngine::ExtensionAndFeatureInfo::queryEngineFeatureExtensionRequirements(const std::string &engineFeature, IEAPI *API) {
-	if (API->name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		return engineFeatureExtensionRequirementQueries[engineFeature][API->version.minor];
-	}
-	return {};
+std::vector<const char *> IERenderEngine::ExtensionAndFeatureInfo::queryEngineFeatureExtensionRequirements(
+  const std::string &engineFeature,
+  IEAPI             *API
+) {
+    if (API->name == IE_RENDER_ENGINE_API_NAME_VULKAN)
+        return engineFeatureExtensionRequirementQueries[engineFeature][API->version.minor];
+    return {};
 }
 
 IERenderEngine::ExtensionAndFeatureInfo::ExtensionAndFeatureInfo() {
-	uint32_t count;
-	vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
-	std::vector<VkExtensionProperties> extensions(count);
-	vkEnumerateInstanceExtensionProperties(nullptr, &count, extensions.data());
-	supportedExtensions.reserve(count);
-	for (VkExtensionProperties extension: extensions) {
-		supportedExtensions.emplace_back(extension.extensionName);
-	}
+    uint32_t count;
+    vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
+    std::vector<VkExtensionProperties> extensions(count);
+    vkEnumerateInstanceExtensionProperties(nullptr, &count, extensions.data());
+    supportedExtensions.reserve(count);
+    for (VkExtensionProperties extension : extensions) supportedExtensions.emplace_back(extension.extensionName);
 }
 
 bool IERenderEngine::ExtensionAndFeatureInfo::rayTracingWithRayQuerySupportQuery() const {
-	return (bufferDeviceAddressFeatures.bufferDeviceAddress & accelerationStructureFeatures.accelerationStructure & rayQueryFeatures.rayQuery &
-			rayTracingPipelineFeatures.rayTracingPipeline) != 0U;
+    return (bufferDeviceAddressFeatures.bufferDeviceAddress & accelerationStructureFeatures.accelerationStructure &
+            rayQueryFeatures.rayQuery & rayTracingPipelineFeatures.rayTracingPipeline) != 0U;
 }
 
 bool IERenderEngine::ExtensionAndFeatureInfo::variableDescriptorCountSupportQuery() const {
-	return descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount != 0U;
+    return descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount != 0U;
 }
 
 IERenderEngine::IERenderEngine(IESettings &settings) {
-	this->settings = &settings;
+    this->settings = &settings;
 
-	// Initialize GLFW then create and setup window
-	/**@todo Clean up this section of the code as it is still quite messy. Optimally this would be done with a GUI abstraction.*/
-	if (glfwInit() != GLFW_TRUE) {
-		settings.logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to initialize GLFW!");
-	}
-	glfwWindowHint(GLFW_SAMPLES, 1);  // 1x MSAA (No MSAA)
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-	#ifndef NDEBUG
-	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
-	#endif
-//	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);  // To make macOS happy. Put into macOS only code block.
-//	glfwWindowHint(GLFW_OPENGL_CORE_PROFILE, GL_TRUE);  // Use Core Profile by default.
-//	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    // Initialize GLFW then create and setup window
+    /**@todo Clean up this section of the code as it is still quite messy. Optimally this would be done with a GUI
+     * abstraction.*/
+    if (glfwInit() != GLFW_TRUE)
+        settings.logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to initialize GLFW!");
+    glfwWindowHint(GLFW_SAMPLES, 1);  // 1x MSAA (No MSAA)
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+#ifndef NDEBUG
+    glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
+#endif
+    //	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);  // To make macOS happy. Put into macOS only code
+    // block. 	glfwWindowHint(GLFW_OPENGL_CORE_PROFILE, GL_TRUE);  // Use Core Profile by default.
+    //	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-	window = createWindow();
+    window = createWindow();
 
-	setWindowIcons("res/icons");
-	glfwSetWindowSizeLimits(window, 1, 1, GLFW_DONT_CARE, GLFW_DONT_CARE);
-	glfwGetWindowPos(window, &(*settings.currentPosition)[0], &(*settings.currentPosition)[1]);
-	glfwSetWindowAttrib(window, GLFW_AUTO_ICONIFY, 0);
-	glfwSetFramebufferSizeCallback(window, framebufferResizeCallback);
-	glfwSetWindowPosCallback(window, windowPositionCallback);
-	glfwSetWindowUserPointer(window, this);
+    setWindowIcons("res/icons");
+    glfwSetWindowSizeLimits(window, 1, 1, GLFW_DONT_CARE, GLFW_DONT_CARE);
+    glfwGetWindowPos(window, &(*settings.currentPosition)[0], &(*settings.currentPosition)[1]);
+    glfwSetWindowAttrib(window, GLFW_AUTO_ICONIFY, 0);
+    glfwSetFramebufferSizeCallback(window, framebufferResizeCallback);
+    glfwSetWindowPosCallback(window, windowPositionCallback);
+    glfwSetWindowUserPointer(window, this);
 
-	// Make context current
-	glfwMakeContextCurrent(window);
-	glfwSwapInterval(settings.vSync ? 1 : 0);
+    // Make context current
+    glfwMakeContextCurrent(window);
+    glfwSwapInterval(settings.vSync ? 1 : 0);
 
-	// Initialize glew
-	glewExperimental = GL_TRUE;
-	if (glewInit() != GLEW_OK) {
-		settings.logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to initialize GLEW!");
-	}
+    // Initialize glew
+    glewExperimental = GL_TRUE;
+    if (glewInit() != GLEW_OK)
+        settings.logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to initialize GLEW!");
 
-	// Get API Version
-	autoDetectAPIVersion(IE_RENDER_ENGINE_API_NAME_OPENGL);
+    // Get API Version
+    autoDetectAPIVersion(IE_RENDER_ENGINE_API_NAME_OPENGL);
 
-	#ifndef NDEBUG
-	glEnable(GL_DEBUG_OUTPUT);
-	glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);  // makes sure errors are displayed synchronously
-	glDebugMessageCallback(&IERenderEngine::glDebugOutput, nullptr);
-	glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, GL_TRUE);
-	#endif
+#ifndef NDEBUG
+    glEnable(GL_DEBUG_OUTPUT);
+    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);  // makes sure errors are displayed synchronously
+    glDebugMessageCallback(&IERenderEngine::glDebugOutput, nullptr);
+    glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, GL_TRUE);
+#endif
 
-	camera.create(this);
-	this->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, reinterpret_cast<const char *>(glGetString(GL_RENDERER)));
-	this->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, API.name + " v" + API.version.name);
+    camera.create(this);
+    this->settings->logger.log(
+      ILLUMINATION_ENGINE_LOG_LEVEL_INFO,
+      reinterpret_cast<const char *>(glGetString(GL_RENDERER))
+    );
+    this->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, API.name + " v" + API.version.name);
 }
 
-void APIENTRY IERenderEngine::glDebugOutput(GLenum source, GLenum type, unsigned int id, GLenum severity, GLsizei, const char *message,
-											const void *) {
-	if (id == 131169 || id == 131185 || id == 131218 || id == 131204) {
-		return; // ignore these non-significant error codes
-	}
-	std::cout << "---------------" << std::endl;
-	std::cout << "Debug message (" << id << "): " << message << std::endl;
-	switch (source) {
-		case GL_DEBUG_SOURCE_API:
-			std::cout << "Source: API";
-			break;
-		case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
-			std::cout << "Source: Window System";
-			break;
-		case GL_DEBUG_SOURCE_SHADER_COMPILER:
-			std::cout << "Source: Shader Compiler";
-			break;
-		case GL_DEBUG_SOURCE_THIRD_PARTY:
-			std::cout << "Source: Third Party";
-			break;
-		case GL_DEBUG_SOURCE_APPLICATION:
-			std::cout << "Source: Application";
-			break;
-		case GL_DEBUG_SOURCE_OTHER:
-			std::cout << "Source: Other";
-			break;
-		default:
-			std::cout << "Source: Unknown";
-			break;
-	}
-	std::cout << std::endl;
-	switch (type) {
-		case GL_DEBUG_TYPE_ERROR:
-			std::cout << "Type: Error";
-			break;
-		case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
-			std::cout << "Type: Deprecated Behaviour";
-			break;
-		case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
-			std::cout << "Type: Undefined Behaviour";
-			break;
-		case GL_DEBUG_TYPE_PORTABILITY:
-			std::cout << "Type: Portability";
-			break;
-		case GL_DEBUG_TYPE_PERFORMANCE:
-			std::cout << "Type: Performance";
-			break;
-		case GL_DEBUG_TYPE_MARKER:
-			std::cout << "Type: Marker";
-			break;
-		case GL_DEBUG_TYPE_PUSH_GROUP:
-			std::cout << "Type: Push Group";
-			break;
-		case GL_DEBUG_TYPE_POP_GROUP:
-			std::cout << "Type: Pop Group";
-			break;
-		case GL_DEBUG_TYPE_OTHER:
-			std::cout << "Type: Other";
-			break;
-		default:
-			std::cout << "Type: Unknown";
-			break;
-	}
-	std::cout << std::endl;
-	switch (severity) {
-		case GL_DEBUG_SEVERITY_HIGH:
-			std::cout << "Severity: high";
-			break;
-		case GL_DEBUG_SEVERITY_MEDIUM:
-			std::cout << "Severity: medium";
-			break;
-		case GL_DEBUG_SEVERITY_LOW:
-			std::cout << "Severity: low";
-			break;
-		case GL_DEBUG_SEVERITY_NOTIFICATION:
-			std::cout << "Severity: notification";
-			break;
-		default:
-			std::cout << "Source: Unknown";
-			break;
-	}
-	std::cout << std::endl;
-	std::cout << std::endl;
+void APIENTRY IERenderEngine::
+  glDebugOutput(GLenum source, GLenum type, unsigned int id, GLenum severity, GLsizei, const char *message, const void *) {
+    if (id == 131169 || id == 131185 || id == 131218 || id == 131204)
+        return;  // ignore these non-significant error codes
+    std::cout << "---------------" << std::endl;
+    std::cout << "Debug message (" << id << "): " << message << std::endl;
+    switch (source) {
+        case GL_DEBUG_SOURCE_API: std::cout << "Source: API"; break;
+        case GL_DEBUG_SOURCE_WINDOW_SYSTEM: std::cout << "Source: Window System"; break;
+        case GL_DEBUG_SOURCE_SHADER_COMPILER: std::cout << "Source: Shader Compiler"; break;
+        case GL_DEBUG_SOURCE_THIRD_PARTY: std::cout << "Source: Third Party"; break;
+        case GL_DEBUG_SOURCE_APPLICATION: std::cout << "Source: Application"; break;
+        case GL_DEBUG_SOURCE_OTHER: std::cout << "Source: Other"; break;
+        default: std::cout << "Source: Unknown"; break;
+    }
+    std::cout << std::endl;
+    switch (type) {
+        case GL_DEBUG_TYPE_ERROR: std::cout << "Type: Error"; break;
+        case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: std::cout << "Type: Deprecated Behaviour"; break;
+        case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR: std::cout << "Type: Undefined Behaviour"; break;
+        case GL_DEBUG_TYPE_PORTABILITY: std::cout << "Type: Portability"; break;
+        case GL_DEBUG_TYPE_PERFORMANCE: std::cout << "Type: Performance"; break;
+        case GL_DEBUG_TYPE_MARKER: std::cout << "Type: Marker"; break;
+        case GL_DEBUG_TYPE_PUSH_GROUP: std::cout << "Type: Push Group"; break;
+        case GL_DEBUG_TYPE_POP_GROUP: std::cout << "Type: Pop Group"; break;
+        case GL_DEBUG_TYPE_OTHER: std::cout << "Type: Other"; break;
+        default: std::cout << "Type: Unknown"; break;
+    }
+    std::cout << std::endl;
+    switch (severity) {
+        case GL_DEBUG_SEVERITY_HIGH: std::cout << "Severity: high"; break;
+        case GL_DEBUG_SEVERITY_MEDIUM: std::cout << "Severity: medium"; break;
+        case GL_DEBUG_SEVERITY_LOW: std::cout << "Severity: low"; break;
+        case GL_DEBUG_SEVERITY_NOTIFICATION: std::cout << "Severity: notification"; break;
+        default: std::cout << "Source: Unknown"; break;
+    }
+    std::cout << std::endl;
+    std::cout << std::endl;
 }
 
 void IERenderEngine::destroy() {
-	_destroy(*this);
+    _destroy(*this);
 }
 
 void IERenderEngine::_openGLDestroy() {
-	glFinish();
-	glfwTerminate();
+    glFinish();
+    glfwTerminate();
 }
 
-std::function<bool(IERenderEngine &)> IERenderEngine::_update = std::function<bool(IERenderEngine &)>{[](IERenderEngine &) { return true; }};
-std::function<void(IERenderEngine &)> IERenderEngine::_destroy = std::function<void(IERenderEngine &)>{[](IERenderEngine &) { return; }};
+std::function<bool(IERenderEngine &)> IERenderEngine::_update =
+  std::function<bool(IERenderEngine &)>{[](IERenderEngine &) {
+      return true;
+  }};
+std::function<void(IERenderEngine &)> IERenderEngine::_destroy =
+  std::function<void(IERenderEngine &)>{[](IERenderEngine &) {
+      return;
+  }};

--- a/src/GraphicsModule/IERenderEngine.hpp
+++ b/src/GraphicsModule/IERenderEngine.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /* Define macros used throughout the file. */
-#define IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING "RayQueryRayTracing"
+#define IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING           "RayQueryRayTracing"
 #define IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT "VariableDescriptorCount"
 
 /* Predefine classes used with pointers or as return values for functions. */
@@ -11,267 +11,288 @@ struct GLFWmonitor;
 
 /* Include classes used as attributes or function arguments. */
 // Internal dependencies
+#include "CommandBuffer/IECommandPool.hpp"
+#include "Core/AssetModule/IEAsset.hpp"
+#include "GraphicsModule/RenderPass/IEFramebuffer.hpp"
+#include "GraphicsModule/RenderPass/IERenderPass.hpp"
 #include "IEAPI.hpp"
 #include "IECamera.hpp"
-#include "GraphicsModule/RenderPass/IERenderPass.hpp"
 #include "IESettings.hpp"
-#include "CommandBuffer/IECommandPool.hpp"
-#include "GraphicsModule/RenderPass/IEFramebuffer.hpp"
 #include "Image/IETexture.hpp"
-#include "Core/AssetModule/IEAsset.hpp"
 #include "Renderable/IERenderable.hpp"
 
 // External dependencies
 #include <VkBootstrap.h>
-
 #include <vulkan/vulkan.h>
 
 // System dependencies
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
-
 
 class IERenderEngine {
 private:
-
-/**
+    /**
      * @brief Private helper function that creates a Vulkan instance.
      * @return The newly created Vulkan instance.
      */
-	vkb::Instance createVulkanInstance();
+    vkb::Instance createVulkanInstance();
 
-	/**
-	 * @brief Creates a window using hardcoded hints and settings from settings.
-	 * @return The window that was just created.
-	 */
-	GLFWwindow *createWindow() const;
+    /**
+     * @brief Creates a window using hardcoded hints and settings from settings.
+     * @return The window that was just created.
+     */
+    GLFWwindow *createWindow() const;
 
-	/**
-	 * @brief Changes the window icon to all of the images found in [path] with a name that contains last part of [path].
-	 * @param path string of path to icons folder plus the identifier.
-	 */
-	void setWindowIcons(const std::filesystem::path &path) const;
+    /**
+     * @brief Changes the window icon to all of the images found in [path] with a
+     * name that contains last part of [path].
+     * @param path string of path to icons folder plus the identifier.
+     */
+    void setWindowIcons(const std::filesystem::path &path) const;
 
-	/**
-	 * @brief Creates a VkSurface for the window.
-	 * @return The newly created surface.
-	 */
-	VkSurfaceKHR createWindowSurface();
+    /**
+     * @brief Creates a VkSurface for the window.
+     * @return The newly created surface.
+     */
+    VkSurfaceKHR createWindowSurface();
 
-	/**
-	 * @brief Creates a physical and logical device with the extensions and features provided activated.
-	 * @param desiredExtensions vector of vectors of Vulkan extension names.
-	 * @param desiredExtensionFeatures pointer to pNext chain of desired features.
-	 * @return The newly created vkb::Device.
-	 */
-	vkb::Device setUpDevice(std::vector<std::vector<const char *>> *desiredExtensions = nullptr, void *desiredExtensionFeatures = nullptr);
+    /**
+     * @brief Creates a physical and logical device with the extensions and
+     * features provided activated.
+     * @param desiredExtensions vector of vectors of Vulkan extension names.
+     * @param desiredExtensionFeatures pointer to pNext chain of desired features.
+     * @return The newly created vkb::Device.
+     */
+    vkb::Device setUpDevice(
+      std::vector<std::vector<const char *>> *desiredExtensions        = nullptr,
+      void                                   *desiredExtensionFeatures = nullptr
+    );
 
-	/**
-	 * @brief Creates a VmaAllocator with no flags activated.
-	 * @return The newly created VmaAllocator.
-	 */
-	VmaAllocator setUpGPUMemoryAllocator();
+    /**
+     * @brief Creates a VmaAllocator with no flags activated.
+     * @return The newly created VmaAllocator.
+     */
+    VmaAllocator setUpGPUMemoryAllocator();
 
-	/**
-	 * @brief Creates a new swapchain. Uses the old swapchain if [useOldSwapchain] is true.
-	 * @param useOldSwapchain
-	 * @return The newly created swapchain.
-	 */
-	vkb::Swapchain createSwapchain(bool useOldSwapchain = true);
+    /**
+     * @brief Creates a new swapchain. Uses the old swapchain if [useOldSwapchain]
+     * is true.
+     * @param useOldSwapchain
+     * @return The newly created swapchain.
+     */
+    vkb::Swapchain createSwapchain(bool useOldSwapchain = true);
 
-	/**
-	 * @brief Creates the basic sync objects. Recreates them if the already exist.
-	 */
-	void createSyncObjects();
+    /**
+     * @brief Creates the basic sync objects. Recreates them if the already exist.
+     */
+    void createSyncObjects();
 
-	/**
-	 * @brief Initializes all the command pools in  Each one is set to use its respective queue.
-	 */
-	void createCommandPools();
+    /**
+     * @brief Initializes all the command pools in  Each one is set to use its
+     * respective queue.
+     */
+    void createCommandPools();
 
-	IEAPI *autoDetectAPIVersion(const std::string &api);
+    IEAPI *autoDetectAPIVersion(const std::string &api);
 
-	/**
-	 * @brief Replaces the only IEGraphicsLink::build() function.
-	 */
-	void buildFunctionPointers();
+    /**
+     * @brief Replaces the only IEGraphicsLink::build() function.
+     */
+    void buildFunctionPointers();
 
-	/**
-	 * @brief Destroys all the sync objects required by the program.
-	 */
-	void destroySyncObjects();
+    /**
+     * @brief Destroys all the sync objects required by the program.
+     */
+    void destroySyncObjects();
 
-	/**
-	 * @brief Destroys the swapchain.
-	 */
-	void destroySwapchain();
+    /**
+     * @brief Destroys the swapchain.
+     */
+    void destroySwapchain();
 
-	/**
-	 * Destroys the command pools and all associated command buffers.
-	 */
-	void destroyCommandPools();
+    /**
+     * Destroys the command pools and all associated command buffers.
+     */
+    void destroyCommandPools();
 
 public:
-	struct ExtensionAndFeatureInfo {
-		// Extension Features
-		// NOTE: Ray tracing features are on the bottom of the pNext stack so that a pointer to higher up on the stack can grab only the structures supported by RenderDoc.
-		VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptorIndexingFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
-		// All the below are ray tracing features, and cannot be loaded by RenderDoc.
-		VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{
-				VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, &descriptorIndexingFeatures};
-		VkPhysicalDeviceBufferDeviceAddressFeaturesEXT bufferDeviceAddressFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
-																				   &accelerationStructureFeatures};
-		VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, &bufferDeviceAddressFeatures};
-		VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR,
-																				 &rayQueryFeatures};
-		void *pNextHighestFeature = &rayTracingPipelineFeatures;
-		void *pNextHighestRenderDocCompatibleFeature = &descriptorIndexingFeatures;
+    struct ExtensionAndFeatureInfo {
+        // Extension Features
+        // NOTE: Ray tracing features are on the bottom of the pNext stack so that a
+        // pointer to higher up on the stack can grab only the structures supported
+        // by RenderDoc.
+        VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptorIndexingFeatures{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+        // All the below are ray tracing features, and cannot be loaded by
+        // RenderDoc.
+        VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR,
+          &descriptorIndexingFeatures};
+        VkPhysicalDeviceBufferDeviceAddressFeaturesEXT bufferDeviceAddressFeatures{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
+          &accelerationStructureFeatures};
+        VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR,
+          &bufferDeviceAddressFeatures};
+        VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR,
+          &rayQueryFeatures};
+        void *pNextHighestFeature                    = &rayTracingPipelineFeatures;
+        void *pNextHighestRenderDocCompatibleFeature = &descriptorIndexingFeatures;
 
-		std::vector<std::string> supportedExtensions;
+        std::vector<std::string> supportedExtensions;
 
-		bool queryFeatureSupport(const std::string &feature);
+        bool queryFeatureSupport(const std::string &feature);
 
-		bool queryExtensionSupport(const std::string &extension);
+        bool queryExtensionSupport(const std::string &extension);
 
-		std::vector<const char *> queryEngineFeatureExtensionRequirements(const std::string &engineFeature, IEAPI *API);
+        std::vector<const char *>
+        queryEngineFeatureExtensionRequirements(const std::string &engineFeature, IEAPI *API);
 
-		ExtensionAndFeatureInfo();
+        ExtensionAndFeatureInfo();
 
-	private:
-		std::unordered_map<std::string, std::vector<std::vector<const char *>>> engineFeatureExtensionRequirementQueries{
-				{  // ray query ray tracing extensions
-						IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING, {
-						{  // 1.0
+    private:
+        std::unordered_map<std::string, std::vector<std::vector<const char *>>>
+          engineFeatureExtensionRequirementQueries{
+            {
+             // ray query ray tracing extensions
+              IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING, {{
+                 // 1.0
 
-						},
-						{  // 1.1
+               },
+               {
+                 // 1.1
 
-						},
-						{  // 1.2
-								VK_KHR_DEVICE_GROUP_EXTENSION_NAME,
-								VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
-								VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-								VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
-								VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
-								VK_KHR_RAY_QUERY_EXTENSION_NAME,
-								VK_KHR_SPIRV_1_4_EXTENSION_NAME
-						},
-						{  // 1.3
-								VK_KHR_DEVICE_GROUP_EXTENSION_NAME,
-								VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
-								VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-								VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
-								VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
-								VK_KHR_RAY_QUERY_EXTENSION_NAME,
-								VK_KHR_SPIRV_1_4_EXTENSION_NAME
-						}
-				},
+               },
+               {// 1.2
+                VK_KHR_DEVICE_GROUP_EXTENSION_NAME,
+                VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+                VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+                VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
+                VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
+                VK_KHR_RAY_QUERY_EXTENSION_NAME,
+                VK_KHR_SPIRV_1_4_EXTENSION_NAME},
+               {// 1.3
+                VK_KHR_DEVICE_GROUP_EXTENSION_NAME,
+                VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+                VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+                VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
+                VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
+                VK_KHR_RAY_QUERY_EXTENSION_NAME,
+                VK_KHR_SPIRV_1_4_EXTENSION_NAME}},
 
-				}
-		};
+             }
+        };
 
-		std::unordered_map<std::string, bool (ExtensionAndFeatureInfo::*)() const> extensionAndFeatureSupportQueries{
-				{IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING,           &ExtensionAndFeatureInfo::rayTracingWithRayQuerySupportQuery},
-				{IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT, &ExtensionAndFeatureInfo::variableDescriptorCountSupportQuery}
-		};
+        std::unordered_map<std::string, bool (ExtensionAndFeatureInfo::*)() const>
+          extensionAndFeatureSupportQueries{
+            {IE_ENGINE_FEATURE_RAY_QUERY_RAY_TRACING,
+             &ExtensionAndFeatureInfo::rayTracingWithRayQuerySupportQuery },
+            {IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT,
+             &ExtensionAndFeatureInfo::variableDescriptorCountSupportQuery}
+        };
 
-		bool rayTracingWithRayQuerySupportQuery() const;
+        bool rayTracingWithRayQuerySupportQuery() const;
 
-		bool variableDescriptorCountSupportQuery() const;
-	};
+        bool variableDescriptorCountSupportQuery() const;
+    };
 
-	explicit IERenderEngine(IESettings *settings = new IESettings{});
+    explicit IERenderEngine(IESettings *settings = new IESettings{});
 
-	void toggleFullscreen();
+    void toggleFullscreen();
 
-	static std::string translateVkResultCodes(VkResult result);
+    static std::string translateVkResultCodes(VkResult result);
 
-	~IERenderEngine();
+    ~IERenderEngine();
 
-	IECamera camera{};
-	std::shared_ptr<IERenderPass> renderPass{};
-	IESettings *settings;
-	std::shared_ptr<IECommandPool> graphicsCommandPool{};
-	std::shared_ptr<IECommandPool> presentCommandPool{};
-	std::shared_ptr<IECommandPool> transferCommandPool{};
-	std::shared_ptr<IECommandPool> computeCommandPool{};
-	IEAPI API;
-	ExtensionAndFeatureInfo extensionAndFeatureInfo{};
-	GLFWmonitor *monitor{};
-	GLFWwindow *window{};
-	vkb::Device device{};
-	vkb::Swapchain swapchain{};
-	vkb::Instance instance{};
-	vkb::detail::Result<vkb::SystemInfo> systemInfo{vkb::SystemInfo::get_system_info()};
-	VkSurfaceKHR surface{};
-	VmaAllocator allocator{};
-	VkQueue graphicsQueue{};
-	VkQueue presentQueue{};
-	VkQueue transferQueue{};
-	VkQueue computeQueue{};
-	PFN_vkGetBufferDeviceAddress vkGetBufferDeviceAddressKHR{};
-	PFN_vkCmdBuildAccelerationStructuresKHR vkCmdBuildAccelerationStructuresKHR{};
-	PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR{};
-	PFN_vkDestroyAccelerationStructureKHR vkDestroyAccelerationStructureKHR{};
-	PFN_vkGetAccelerationStructureBuildSizesKHR vkGetAccelerationStructureBuildSizesKHR{};
-	PFN_vkGetAccelerationStructureDeviceAddressKHR vkGetAccelerationStructureDeviceAddressKHR{};
-	PFN_vkAcquireNextImageKHR vkAcquireNextImageKhr{};
-	std::vector<std::shared_ptr<IETexture>> textures{};
-	std::vector<VkImageView> swapchainImageViews{};
-	std::vector<std::weak_ptr<IERenderable>> renderables{};
-	float frameTime{};
-	int frameNumber{};
-	// global depth image used by all framebuffers. Should this be here?
-	std::shared_ptr<IEImage> depthImage{};
+    IECamera                                       camera{};
+    std::shared_ptr<IERenderPass>                  renderPass{};
+    IESettings                                    *settings;
+    std::shared_ptr<IECommandPool>                 graphicsCommandPool{};
+    std::shared_ptr<IECommandPool>                 presentCommandPool{};
+    std::shared_ptr<IECommandPool>                 transferCommandPool{};
+    std::shared_ptr<IECommandPool>                 computeCommandPool{};
+    IEAPI                                          API;
+    ExtensionAndFeatureInfo                        extensionAndFeatureInfo{};
+    GLFWmonitor                                   *monitor{};
+    GLFWwindow                                    *window{};
+    vkb::Device                                    device{};
+    vkb::Swapchain                                 swapchain{};
+    vkb::Instance                                  instance{};
+    vkb::Result<vkb::SystemInfo>                   systemInfo{vkb::SystemInfo::get_system_info()};
+    VkSurfaceKHR                                   surface{};
+    VmaAllocator                                   allocator{};
+    VkQueue                                        graphicsQueue{};
+    VkQueue                                        presentQueue{};
+    VkQueue                                        transferQueue{};
+    VkQueue                                        computeQueue{};
+    PFN_vkGetBufferDeviceAddress                   vkGetBufferDeviceAddressKHR{};
+    PFN_vkCmdBuildAccelerationStructuresKHR        vkCmdBuildAccelerationStructuresKHR{};
+    PFN_vkCreateAccelerationStructureKHR           vkCreateAccelerationStructureKHR{};
+    PFN_vkDestroyAccelerationStructureKHR          vkDestroyAccelerationStructureKHR{};
+    PFN_vkGetAccelerationStructureBuildSizesKHR    vkGetAccelerationStructureBuildSizesKHR{};
+    PFN_vkGetAccelerationStructureDeviceAddressKHR vkGetAccelerationStructureDeviceAddressKHR{};
+    PFN_vkAcquireNextImageKHR                      vkAcquireNextImageKhr{};
+    std::vector<std::shared_ptr<IETexture>>        textures{};
+    std::vector<VkImageView>                       swapchainImageViews{};
+    std::vector<std::weak_ptr<IERenderable>>       renderables{};
+    float                                          frameTime{};
+    int                                            frameNumber{};
+    // global depth image used by all framebuffers. Should this be here?
+    std::shared_ptr<IEImage>                       depthImage{};
 
-	void addAsset(const std::shared_ptr<IEAsset> &asset);
+    void addAsset(const std::shared_ptr<IEAsset> &asset);
 
-	explicit IERenderEngine(IESettings &settings);
+    explicit IERenderEngine(IESettings &settings);
 
-	bool update();
+    bool update();
 
 private:
-	std::vector<VkFence> inFlightFences{};
-	std::vector<VkFence> imagesInFlight{};
-	std::vector<VkSemaphore> imageAvailableSemaphores{};
-	std::vector<VkSemaphore> renderFinishedSemaphores{};
-	std::vector<std::function<void()>> fullRecreationDeletionQueue{};
-	std::vector<std::function<void()>> recreationDeletionQueue{};
-	std::vector<std::function<void()>> renderableDeletionQueue{};
-	std::vector<std::function<void()>> deletionQueue{};
-	size_t currentFrame{};
-	bool framebufferResized{false};
-	float previousTime{};
+    std::vector<VkFence>               inFlightFences{};
+    std::vector<VkFence>               imagesInFlight{};
+    std::vector<VkSemaphore>           imageAvailableSemaphores{};
+    std::vector<VkSemaphore>           renderFinishedSemaphores{};
+    std::vector<std::function<void()>> fullRecreationDeletionQueue{};
+    std::vector<std::function<void()>> recreationDeletionQueue{};
+    std::vector<std::function<void()>> renderableDeletionQueue{};
+    std::vector<std::function<void()>> deletionQueue{};
+    size_t                             currentFrame{};
+    bool                               framebufferResized{false};
+    float                              previousTime{};
 
+    static std::function<bool(IERenderEngine &)> _update;
 
-	static std::function<bool(IERenderEngine &)> _update;
+    bool _openGLUpdate();
 
-	bool _openGLUpdate();
+    bool _vulkanUpdate();
 
-	bool _vulkanUpdate();
+    static std::function<void(IERenderEngine &)> _destroy;
 
+    void _openGLDestroy();
 
-	static std::function<void(IERenderEngine &)> _destroy;
+    void _vulkanDestroy();
 
-	void _openGLDestroy();
+    void destroy();
 
-	void _vulkanDestroy();
+    static void framebufferResizeCallback(GLFWwindow *pWindow, int width, int height);
 
-	void destroy();
+    void createRenderPass();
 
+    void handleResolutionChange();
 
-	static void framebufferResizeCallback(GLFWwindow *pWindow, int width, int height);
-
-	void createRenderPass();
-
-	void handleResolutionChange();
-
-	static void windowPositionCallback(GLFWwindow *pWindow, int x, int y);
+    static void windowPositionCallback(GLFWwindow *pWindow, int x, int y);
 
 public:
+    static void APIENTRY glDebugOutput(
+      GLenum       source,
+      GLenum       type,
+      unsigned int id,
+      GLenum       severity,
+      GLsizei      length,
+      const char  *message,
+      const void  *userParam
+    );
 
-	static void APIENTRY glDebugOutput(GLenum source, GLenum type, unsigned int id, GLenum severity, GLsizei length, const char *message, const void *userParam);
-
-	static void setAPI(const IEAPI &API);
+    static void setAPI(const IEAPI &API);
 };

--- a/src/GraphicsModule/IESettings.hpp
+++ b/src/GraphicsModule/IESettings.hpp
@@ -16,6 +16,7 @@
 #include <vulkan/vulkan.h>
 
 #define GLEW_IMPLEMENTATION
+
 #include <include/GL/glew.h>
 
 #include <GLFW/glfw3.h>
@@ -28,44 +29,44 @@
 
 class IESettings {
 public:
-	IESettings() {
-		glfwInit();
-		primaryMonitor = glfwGetPrimaryMonitor();
-		defaultResolution = {800, 600};
-		fullscreenResolution = {glfwGetVideoMode(primaryMonitor)->width, glfwGetVideoMode(primaryMonitor)->height};
-		windowedResolution = {defaultResolution};
-		currentResolution = fullscreen ? &fullscreenResolution : &windowedResolution;
-		defaultPosition = {(glfwGetVideoMode(primaryMonitor)->width - windowedResolution[0]) / 2,
-						   (glfwGetVideoMode(primaryMonitor)->height - windowedResolution[1]) / 2};
-		fullscreenPosition = {0, 0};
-		windowedPosition = {defaultPosition};
-		currentPosition = fullscreen ? &fullscreenPosition : &windowedPosition;
-	}
+    IESettings() {
+        glfwInit();
+        primaryMonitor = glfwGetPrimaryMonitor();
+        defaultResolution = {800, 600};
+        fullscreenResolution = {glfwGetVideoMode(primaryMonitor)->width, glfwGetVideoMode(primaryMonitor)->height};
+        windowedResolution = {defaultResolution};
+        currentResolution = fullscreen ? &fullscreenResolution : &windowedResolution;
+        defaultPosition = {(glfwGetVideoMode(primaryMonitor)->width - windowedResolution[0]) / 2,
+                           (glfwGetVideoMode(primaryMonitor)->height - windowedResolution[1]) / 2};
+        fullscreenPosition = {0, 0};
+        windowedPosition = {defaultPosition};
+        currentPosition = fullscreen ? &fullscreenPosition : &windowedPosition;
+    }
 
-	IELogger logger{};
-	bool rayTracing{false};
-	std::string applicationName{"Illumination Engine"};
-	IEVersion applicationVersion{0, 0, 1};
-	IEVersion minimumVulkanVersion{1, 0, 0};
-	IEVersion desiredVulkanVersion{1, 2, 0};
-	uint8_t msaaSamples{VK_SAMPLE_COUNT_1_BIT};
-	float anisotropicFilterLevel{16.0f};
-	bool mipMapping{true};
-	float mipMapLevel{0};
-	bool fullscreen{false};
-	int refreshRate{60};
-	bool vSync{true};
-	GLFWmonitor *primaryMonitor;
-	std::array<int, 2> defaultResolution{};
-	std::array<int, 2> fullscreenResolution{};
-	std::array<int, 2> windowedResolution{};
-	std::array<int, 2> *currentResolution;
-	std::array<int, 2> defaultPosition{};
-	std::array<int, 2> fullscreenPosition{};
-	std::array<int, 2> windowedPosition{};
-	std::array<int, 2> *currentPosition;
-	double fov{90};
-	double renderDistance{1000000};
-	double mouseSensitivity{0.1};
-	float movementSpeed{2.5};
+    IELogger logger{};
+    bool rayTracing{false};
+    std::string applicationName{"Illumination Engine"};
+    IEVersion applicationVersion{0, 0, 1};
+    IEVersion minimumVulkanVersion{1, 0, 0};
+    IEVersion desiredVulkanVersion{1, 2, 0};
+    uint8_t msaaSamples{VK_SAMPLE_COUNT_1_BIT};
+    float anisotropicFilterLevel{16.0f};
+    bool mipMapping{true};
+    float mipMapLevel{0};
+    bool fullscreen{false};
+    int refreshRate{60};
+    bool vSync{true};
+    GLFWmonitor *primaryMonitor;
+    std::array<int, 2> defaultResolution{};
+    std::array<int, 2> fullscreenResolution{};
+    std::array<int, 2> windowedResolution{};
+    std::array<int, 2> *currentResolution;
+    std::array<int, 2> defaultPosition{};
+    std::array<int, 2> fullscreenPosition{};
+    std::array<int, 2> windowedPosition{};
+    std::array<int, 2> *currentPosition;
+    double fov{90};
+    double renderDistance{1000000};
+    double mouseSensitivity{0.1};
+    float movementSpeed{2.5};
 };

--- a/src/GraphicsModule/IEVersion.cpp
+++ b/src/GraphicsModule/IEVersion.cpp
@@ -4,45 +4,45 @@
 /* Include external dependencies. */
 #include <vulkan/vulkan.h>
 
-
 IEVersion::IEVersion(const std::string &versionName) {
-	uint32_t nameLength = (name + ' ').find_first_of(' ');
-	name = versionName.substr(0, nameLength);
-	uint32_t firstBreak = name.find_first_of('.');
-	uint32_t secondBreak = name.substr(firstBreak + 1, nameLength - firstBreak).find_first_of('.') + firstBreak + 1;
-	major = std::stoul(name.substr(0, firstBreak));
-	minor = std::stoul(name.substr(firstBreak + 1, secondBreak - firstBreak));
-	patch = std::stoul(name.substr(secondBreak + 1, nameLength - secondBreak));
-	version = {major, minor, patch};
-	number = (major << 22) | (minor << 12) | patch;
-	number = VK_MAKE_VERSION(major, minor, patch);
+    uint32_t nameLength = (name + ' ').find_first_of(' ');
+    name                = versionName.substr(0, nameLength);
+    uint32_t firstBreak = name.find_first_of('.');
+    uint32_t secondBreak =
+      name.substr(firstBreak + 1, nameLength - firstBreak).find_first_of('.') + firstBreak + 1;
+    major   = std::stoul(name.substr(0, firstBreak));
+    minor   = std::stoul(name.substr(firstBreak + 1, secondBreak - firstBreak));
+    patch   = std::stoul(name.substr(secondBreak + 1, nameLength - secondBreak));
+    version = {major, minor, patch};
+    number  = (major << 22) | (minor << 12) | patch;
+    number  = VK_MAKE_VERSION(major, minor, patch);
 }
 
 IEVersion::IEVersion(const std::vector<uint32_t> &versionNumbers) {
-	version = versionNumbers;
-	major = versionNumbers[0];
-	minor = versionNumbers[1];
-	patch = versionNumbers[2];
-	name = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
-	number = VK_MAKE_VERSION(major, minor, patch);
+    version = versionNumbers;
+    major   = versionNumbers[0];
+    minor   = versionNumbers[1];
+    patch   = versionNumbers[2];
+    name    = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+    number  = VK_MAKE_VERSION(major, minor, patch);
 }
 
 IEVersion::IEVersion(uint32_t versionMajor, uint32_t versionMinor, uint32_t versionPatch) {
-	major = versionMajor;
-	minor = versionMinor;
-	patch = versionPatch;
-	name = std::to_string(versionMajor) + "." + std::to_string(versionMinor) + "." + std::to_string(versionPatch);
-	version = {versionMajor, versionMinor, versionPatch};
-	number = VK_MAKE_VERSION(major, minor, patch);
+    major = versionMajor;
+    minor = versionMinor;
+    patch = versionPatch;
+    name  = std::to_string(versionMajor) + "." + std::to_string(versionMinor) + "." + std::to_string(versionPatch);
+    version = {versionMajor, versionMinor, versionPatch};
+    number  = VK_MAKE_VERSION(major, minor, patch);
 }
 
 IEVersion::IEVersion(uint32_t versionNumber) {
-	number = versionNumber;
-	major = VK_VERSION_MAJOR(versionNumber);
-	minor = VK_VERSION_MINOR(versionNumber);
-	patch = VK_VERSION_PATCH(versionNumber);
-	name = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
-	version = {major, minor, patch};
+    number  = versionNumber;
+    major   = VK_VERSION_MAJOR(versionNumber);
+    minor   = VK_VERSION_MINOR(versionNumber);
+    patch   = VK_VERSION_PATCH(versionNumber);
+    name    = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+    version = {major, minor, patch};
 }
 
 IEVersion::IEVersion() = default;

--- a/src/GraphicsModule/IEVersion.hpp
+++ b/src/GraphicsModule/IEVersion.hpp
@@ -6,23 +6,22 @@
 #include <string>
 #include <vector>
 
-
 struct IEVersion {
 public:
-	std::string name{"0.0.0"};
-	std::vector<uint32_t> version{0, 0, 0};
-	uint32_t major{};
-	uint32_t minor{};
-	uint32_t patch{};
-	uint32_t number{};
+    std::string           name{"0.0.0"};
+    std::vector<uint32_t> version{0, 0, 0};
+    uint32_t              major{};
+    uint32_t              minor{};
+    uint32_t              patch{};
+    uint32_t              number{};
 
-	explicit IEVersion(const std::string &versionName);
+    explicit IEVersion(const std::string &versionName);
 
-	explicit IEVersion(const std::vector<uint32_t> &versionNumbers);
+    explicit IEVersion(const std::vector<uint32_t> &versionNumbers);
 
-	IEVersion(uint32_t versionMajor, uint32_t versionMinor, uint32_t versionPatch);
+    IEVersion(uint32_t versionMajor, uint32_t versionMinor, uint32_t versionPatch);
 
-	explicit IEVersion(uint32_t versionNumber);
+    explicit IEVersion(uint32_t versionNumber);
 
-	IEVersion();
+    IEVersion();
 };

--- a/src/GraphicsModule/Image/IEImage.cpp
+++ b/src/GraphicsModule/Image/IEImage.cpp
@@ -8,668 +8,736 @@
 /* Include dependencies from Core. */
 #include "Core/LogModule/IELogger.hpp"
 
-
 [[maybe_unused]] [[nodiscard]] uint8_t IEImage::getHighestMSAASampleCount(uint8_t requested) const {
-	uint8_t count = 1;
-	VkImageFormatProperties properties{};
-	vkGetPhysicalDeviceImageFormatProperties(linkedRenderEngine->device.physical_device, format, type, tiling, usage, flags, &properties);
-	return std::max(count, std::min(static_cast<uint8_t>(properties.sampleCounts), std::min(requested, linkedRenderEngine->settings->msaaSamples)));
+    uint8_t                 count = 1;
+    VkImageFormatProperties properties{};
+    vkGetPhysicalDeviceImageFormatProperties(
+      linkedRenderEngine->device.physical_device,
+      format,
+      type,
+      tiling,
+      usage,
+      flags,
+      &properties
+    );
+    return std::max(
+      count,
+      std::min(
+        static_cast<uint8_t>(properties.sampleCounts),
+        std::min(requested, linkedRenderEngine->settings->msaaSamples)
+      )
+    );
 }
 
 [[maybe_unused]] [[nodiscard]] float IEImage::getHighestAnisotropyLevel(float requested) const {
-	float anisotropyLevel = 1.0F;
-	VkPhysicalDeviceProperties properties{};
-	vkGetPhysicalDeviceProperties(linkedRenderEngine->device.physical_device, &properties);
-	return std::max(anisotropyLevel, std::min(properties.limits.maxSamplerAnisotropy, requested));
+    float                      anisotropyLevel = 1.0F;
+    VkPhysicalDeviceProperties properties{};
+    vkGetPhysicalDeviceProperties(linkedRenderEngine->device.physical_device, &properties);
+    return std::max(anisotropyLevel, std::min(properties.limits.maxSamplerAnisotropy, requested));
 }
 
 IEImage::IEImage(IERenderEngine *engineLink, IEImage::CreateInfo *createInfo) {
-	create(engineLink, createInfo);
+    create(engineLink, createInfo);
 }
 
 IEImage::~IEImage() {
-	if (status != IE_IMAGE_STATUS_UNLOADED) {
-		_destroy(*this);
-	}
+    if (status != IE_IMAGE_STATUS_UNLOADED) _destroy(*this);
 }
 
 void IEImage::setAPI(const IEAPI &API) {
-	IETexture::setAPI(API);
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_uploadToRAM = &IEImage::_openglUploadToRAM;
-		_uploadToVRAM = &IEImage::_openglUploadToVRAM;
-		_update_vector = &IEImage::_openglUpdate_vector;
-		_update_void = &IEImage::_openglUpdate_voidPtr;
-		_unloadFromVRAM = &IEImage::_openglUnloadFromVRAM;
-		_destroy = &IEImage::_openglDestroy;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_uploadToRAM = &IEImage::_vulkanUploadToRAM;
-		_uploadToVRAM = &IEImage::_vulkanUploadToVRAM;
-		_update_vector = &IEImage::_vulkanUpdate_vector;
-		_update_void = &IEImage::_vulkanUpdate_voidPtr;
-		_unloadFromVRAM = &IEImage::_vulkanUnloadFromVRAM;
-		_destroy = &IEImage::_vulkanDestroy;
-	}
+    IETexture::setAPI(API);
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _uploadToRAM    = &IEImage::_openglUploadToRAM;
+        _uploadToVRAM   = &IEImage::_openglUploadToVRAM;
+        _update_vector  = &IEImage::_openglUpdate_vector;
+        _update_void    = &IEImage::_openglUpdate_voidPtr;
+        _unloadFromVRAM = &IEImage::_openglUnloadFromVRAM;
+        _destroy        = &IEImage::_openglDestroy;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _uploadToRAM    = &IEImage::_vulkanUploadToRAM;
+        _uploadToVRAM   = &IEImage::_vulkanUploadToVRAM;
+        _update_vector  = &IEImage::_vulkanUpdate_vector;
+        _update_void    = &IEImage::_vulkanUpdate_voidPtr;
+        _unloadFromVRAM = &IEImage::_vulkanUnloadFromVRAM;
+        _destroy        = &IEImage::_vulkanDestroy;
+    }
 }
-
 
 void IEImage::create(IERenderEngine *engineLink, IEImage::CreateInfo *createInfo) {
-	linkedRenderEngine = engineLink;
+    linkedRenderEngine = engineLink;
 
-	// Copy createInfo data into this image
-	format = createInfo->format;
-	layout = createInfo->layout;
-	type = createInfo->type;
-	usage = createInfo->usage;
-	flags = createInfo->flags;
-	aspect = createInfo->aspect;
-	allocationUsage = createInfo->allocationUsage;
-	width = createInfo->width;
-	height = createInfo->height;
-	channels = createInfo->channels;
-	data = createInfo->data;
+    // Copy createInfo data into this image
+    format          = createInfo->format;
+    layout          = createInfo->layout;
+    type            = createInfo->type;
+    usage           = createInfo->usage;
+    flags           = createInfo->flags;
+    aspect          = createInfo->aspect;
+    allocationUsage = createInfo->allocationUsage;
+    width           = createInfo->width;
+    height          = createInfo->height;
+    channels        = createInfo->channels;
+    data            = createInfo->data;
 
-	status = IE_IMAGE_STATUS_UNLOADED;
+    status = IE_IMAGE_STATUS_UNLOADED;
 }
-
 
 std::function<void(IEImage &)> IEImage::_uploadToRAM{nullptr};
 
 void IEImage::uploadToRAM() {
-	status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_QUEUED_RAM);
-	if (status & IE_IMAGE_STATUS_IN_VRAM) {
-		_uploadToRAM(*this);
-	}
-	status = static_cast<IEImageStatus>(status & ~IE_IMAGE_STATUS_QUEUED_RAM | IE_IMAGE_STATUS_IN_RAM);
+    status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_QUEUED_RAM);
+    if (status & IE_IMAGE_STATUS_IN_VRAM) _uploadToRAM(*this);
+    status = static_cast<IEImageStatus>(status & ~IE_IMAGE_STATUS_QUEUED_RAM | IE_IMAGE_STATUS_IN_RAM);
 }
 
-void IEImage::_openglUploadToRAM() {} /**@todo Do later.*/
+void IEImage::_openglUploadToRAM() {
+} /**@todo Do later.*/
 
 void IEImage::_vulkanUploadToRAM() {
-	std::shared_ptr<IEBuffer> stagingBuffer = std::make_shared<IEBuffer>();
-	/**@todo Remove the size parameter requirements optionally.*/
-	toBuffer(stagingBuffer, width * height * channels);  // Convert this image to a buffer
-	stagingBuffer->uploadToRAM();
-	data = stagingBuffer->data;
+    std::shared_ptr<IEBuffer> stagingBuffer = std::make_shared<IEBuffer>();
+    /**@todo Remove the size parameter requirements optionally.*/
+    toBuffer(stagingBuffer, width * height * channels);  // Convert this image to a buffer
+    stagingBuffer->uploadToRAM();
+    data = stagingBuffer->data;
 }
 
 void IEImage::uploadToRAM(const std::vector<char> &data) {
-	if (data.empty() && this->data.empty()) {
-		status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_QUEUED_RAM);
-		return;
-	}
-	if (data.size() > width * height * channels) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to load in more data to RAM than can fit in image!");
-	}
-	if (status & IE_IMAGE_STATUS_QUEUED_RAM || status & IE_IMAGE_STATUS_IN_RAM) {
-		if (data.size() > width * height * channels) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "");
-		}
-		this->data = data;
-	}
+    if (data.empty() && this->data.empty()) {
+        status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_QUEUED_RAM);
+        return;
+    }
+    if (data.size() > width * height * channels) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Attempt to load in more data to RAM than can fit in image!"
+        );
+    }
+    if (status & IE_IMAGE_STATUS_QUEUED_RAM || status & IE_IMAGE_STATUS_IN_RAM) {
+        if (data.size() > width * height * channels)
+            linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "");
+        this->data = data;
+    }
 }
 
 void IEImage::uploadToRAM(void *data, size_t size) {
-	if (size == 0) {
-		status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_QUEUED_RAM);
-		return;
-	}
-	if (size > width * height * channels) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to load in more data to RAM than can fit in image!");
-	}
-	if (status & IE_IMAGE_STATUS_QUEUED_RAM || status & IE_IMAGE_STATUS_IN_RAM) {
-		if (size > width * height * channels) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "");
-		}
-		size_t i = 0;
-		std::generate(this->data.begin(), this->data.end(), [&] { return *(char *) ((size_t) data + i++); });
-	}
+    if (size == 0) {
+        status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_QUEUED_RAM);
+        return;
+    }
+    if (size > width * height * channels) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Attempt to load in more data to RAM than can fit in image!"
+        );
+    }
+    if (status & IE_IMAGE_STATUS_QUEUED_RAM || status & IE_IMAGE_STATUS_IN_RAM) {
+        if (size > width * height * channels)
+            linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "");
+        size_t i = 0;
+        std::generate(this->data.begin(), this->data.end(), [&] { return *(char *) ((size_t) data + i++); });
+    }
 }
-
 
 std::function<void(IEImage &)> IEImage::_uploadToVRAM{nullptr};
 
 void IEImage::uploadToVRAM() {
-	_uploadToVRAM(*this);
-	status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
+    _uploadToVRAM(*this);
+    status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
 }
 
 void IEImage::_openglUploadToVRAM() {
-	glGenTextures(1, &id);
-	glBindTexture(GL_TEXTURE_2D, id);
-	
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_SRGB8_ALPHA8, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
-	glBindTexture(GL_TEXTURE_2D, 0);
+    glGenTextures(1, &id);
+    glBindTexture(GL_TEXTURE_2D, id);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glTexImage2D(
+      GL_TEXTURE_2D,
+      0,
+      GL_SRGB8_ALPHA8,
+      (GLsizei) width,
+      (GLsizei) height,
+      0,
+      GL_RGBA,
+      GL_UNSIGNED_BYTE,
+      data.data()
+    );
+    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 void IEImage::_vulkanUploadToVRAM() {
-	VkImageLayout desiredLayout = layout;
-	layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    VkImageLayout desiredLayout = layout;
+    layout                      = VK_IMAGE_LAYOUT_UNDEFINED;
 
-	_vulkanCreateImage();
-	_vulkanCreateImageView();
+    _vulkanCreateImage();
+    _vulkanCreateImageView();
 
-	if (aspect & VK_IMAGE_ASPECT_COLOR_BIT) {
+    if (aspect & VK_IMAGE_ASPECT_COLOR_BIT) {
 
-		// Used to build the image in video memory.
-		std::shared_ptr<IEBuffer> scratchBuffer = std::make_shared<IEBuffer>(linkedRenderEngine, width * height * channels * getBytesInFormat(),
-																			 VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU, NULL);
-		scratchBuffer->uploadToVRAM(data);
-		scratchBuffer->toImage(shared_from_this());
-
-	}
-	// Set transition to requested layout from undefined or dst_optimal.
-	if (layout != desiredLayout) {
-		transitionLayout(desiredLayout);
-	}
+        // Used to build the image in video memory.
+        std::shared_ptr<IEBuffer> scratchBuffer = std::make_shared<IEBuffer>(
+          linkedRenderEngine,
+          width * height * channels * getBytesInFormat(),
+          VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+          VMA_MEMORY_USAGE_CPU_TO_GPU,
+          NULL
+        );
+        scratchBuffer->uploadToVRAM(data);
+        scratchBuffer->toImage(shared_from_this());
+    }
+    // Set transition to requested layout from undefined or dst_optimal.
+    if (layout != desiredLayout) transitionLayout(desiredLayout);
 }
-
-
 
 std::function<void(IEImage &, const std::vector<char> &)> IEImage::_uploadToVRAM_vector{nullptr};
 
 void IEImage::uploadToVRAM(const std::vector<char> &data) {
-	_uploadToVRAM_vector(*this, data);
-	status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
+    _uploadToVRAM_vector(*this, data);
+    status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
 }
 
 void IEImage::_openglUploadToVRAM_vector(const std::vector<char> &data) {
-
 }
 
 void IEImage::_vulkanUploadToVRAM_vector(const std::vector<char> &data) {
-
 }
-
 
 std::function<void(IEImage &, void *, size_t)> IEImage::_uploadToVRAM_void{nullptr};
 
 void IEImage::uploadToVRAM(void *, size_t) {
-
 }
 
 void IEImage::_openglUploadToVRAM_void(void *data, size_t size) {
-
 }
 
 void IEImage::_vulkanUploadToVRAM_void(void *data, size_t size) {
-
 }
-
 
 std::function<void(IEImage &, const std::vector<char> &)> IEImage::_update_vector{nullptr};
 
 void IEImage::update(const std::vector<char> &data) {
-	_update_vector(*this, data);
+    _update_vector(*this, data);
 }
 
 void IEImage::_openglUpdate_vector(const std::vector<char> &data) {
-	if (status & IE_IMAGE_STATUS_IN_RAM) {
-		this->data = data;
-	}
-	if (status & IE_IMAGE_STATUS_IN_VRAM) {
-		// Used to build the image in video memory.
-		glBindTexture(GL_TEXTURE_2D, id);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_SRGB8_ALPHA8, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
-		glBindTexture(GL_TEXTURE_2D, 0);
-	}
+    if (status & IE_IMAGE_STATUS_IN_RAM) this->data = data;
+    if (status & IE_IMAGE_STATUS_IN_VRAM) {
+        // Used to build the image in video memory.
+        glBindTexture(GL_TEXTURE_2D, id);
+        glTexImage2D(
+          GL_TEXTURE_2D,
+          0,
+          GL_SRGB8_ALPHA8,
+          (GLsizei) width,
+          (GLsizei) height,
+          0,
+          GL_RGBA,
+          GL_UNSIGNED_BYTE,
+          data.data()
+        );
+        glBindTexture(GL_TEXTURE_2D, 0);
+    }
 }
 
 void IEImage::_vulkanUpdate_vector(const std::vector<char> &data) {
-	if (status & IE_IMAGE_STATUS_IN_RAM) {
-		this->data = data;
-	}
-	if (status & IE_IMAGE_STATUS_IN_VRAM) {
-		// Used to build the image in video memory.
-		std::shared_ptr<IEBuffer> scratchBuffer = std::make_shared<IEBuffer>(linkedRenderEngine, data.size(), VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-																			 VMA_MEMORY_USAGE_CPU_TO_GPU, NULL);
-		scratchBuffer->uploadToVRAM(data);
-		scratchBuffer->toImage(shared_from_this());
-	}
+    if (status & IE_IMAGE_STATUS_IN_RAM) this->data = data;
+    if (status & IE_IMAGE_STATUS_IN_VRAM) {
+        // Used to build the image in video memory.
+        std::shared_ptr<IEBuffer> scratchBuffer = std::make_shared<IEBuffer>(
+          linkedRenderEngine,
+          data.size(),
+          VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+          VMA_MEMORY_USAGE_CPU_TO_GPU,
+          NULL
+        );
+        scratchBuffer->uploadToVRAM(data);
+        scratchBuffer->toImage(shared_from_this());
+    }
 }
-
 
 std::function<void(IEImage &, void *, size_t)> IEImage::_update_void{nullptr};
 
 void IEImage::update(void *data, size_t size) {
-	_update_void(*this, data, size);
+    _update_void(*this, data, size);
 }
 
 void IEImage::_openglUpdate_voidPtr(void *data, size_t size) {
-	if (status & IE_IMAGE_STATUS_IN_RAM) {
-		this->data = std::vector<char>{(char *) data, (char *) data + size};
-	}
-	if (status & IE_IMAGE_STATUS_IN_VRAM) {
-		// Used to build the image in video memory.
-		glBindTexture(GL_TEXTURE_2D, id);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_SRGB8_ALPHA8, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-		glBindTexture(GL_TEXTURE_2D, 0);
-	}
+    if (status & IE_IMAGE_STATUS_IN_RAM) this->data = std::vector<char>{(char *) data, (char *) data + size};
+    if (status & IE_IMAGE_STATUS_IN_VRAM) {
+        // Used to build the image in video memory.
+        glBindTexture(GL_TEXTURE_2D, id);
+        glTexImage2D(
+          GL_TEXTURE_2D,
+          0,
+          GL_SRGB8_ALPHA8,
+          (GLsizei) width,
+          (GLsizei) height,
+          0,
+          GL_RGBA,
+          GL_UNSIGNED_BYTE,
+          data
+        );
+        glBindTexture(GL_TEXTURE_2D, 0);
+    }
 }
 
 void IEImage::_vulkanUpdate_voidPtr(void *data, size_t size) {
-	if (status & IE_IMAGE_STATUS_IN_RAM) {
-		this->data = std::vector<char>{(char *) data, (char *) data + size};
-	}
-	if (status & IE_IMAGE_STATUS_IN_VRAM) {
-		// Used to build the image in video memory.
-		std::shared_ptr<IEBuffer> scratchBuffer = std::make_shared<IEBuffer>(linkedRenderEngine, size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-																			 VMA_MEMORY_USAGE_CPU_TO_GPU, NULL);
-		scratchBuffer->uploadToVRAM(data, size);
-		scratchBuffer->toImage(shared_from_this());
-	}
+    if (status & IE_IMAGE_STATUS_IN_RAM) this->data = std::vector<char>{(char *) data, (char *) data + size};
+    if (status & IE_IMAGE_STATUS_IN_VRAM) {
+        // Used to build the image in video memory.
+        std::shared_ptr<IEBuffer> scratchBuffer = std::make_shared<IEBuffer>(
+          linkedRenderEngine,
+          size,
+          VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+          VMA_MEMORY_USAGE_CPU_TO_GPU,
+          NULL
+        );
+        scratchBuffer->uploadToVRAM(data, size);
+        scratchBuffer->toImage(shared_from_this());
+    }
 }
-
 
 std::function<void(IEImage &)> IEImage::_unloadFromVRAM{nullptr};
 
 void IEImage::unloadFromVRAM() {
-	_unloadFromVRAM(*this);
+    _unloadFromVRAM(*this);
 }
 
 void IEImage::_openglUnloadFromVRAM() {
-
 }
 
 void IEImage::_vulkanUnloadFromVRAM() {
-	vmaDestroyImage(linkedRenderEngine->allocator, image, allocation);
-	vkDestroyImageView(linkedRenderEngine->device.device, view, nullptr);
-	vkDestroySampler(linkedRenderEngine->device.device, sampler, nullptr);
-	invalidateDependents();
+    vmaDestroyImage(linkedRenderEngine->allocator, image, allocation);
+    vkDestroyImageView(linkedRenderEngine->device.device, view, nullptr);
+    vkDestroySampler(linkedRenderEngine->device.device, sampler, nullptr);
+    invalidateDependents();
 }
-
 
 std::function<void(IEImage &)> IEImage::_destroy{nullptr};
 
 void IEImage::destroy() {
-	if (status != IE_IMAGE_STATUS_UNLOADED) {
-		_destroy(*this);
-	}
+    if (status != IE_IMAGE_STATUS_UNLOADED) _destroy(*this);
 }
 
 void IEImage::_openglDestroy() {
-
 }
 
 void IEImage::_vulkanDestroy() {
-	_vulkanUnloadFromVRAM();
+    _vulkanUnloadFromVRAM();
 }
 
-
 void IEImage::toBuffer(const std::shared_ptr<IEBuffer> &buffer, uint32_t commandBufferIndex) const {
-	VkBufferImageCopy region{};
-	region.bufferOffset = 0;
-	region.bufferRowLength = 0;
-	region.bufferImageHeight = 0;
-	region.imageSubresource.aspectMask = format == linkedRenderEngine->swapchain.image_format ? VK_IMAGE_ASPECT_COLOR_BIT : VK_IMAGE_ASPECT_DEPTH_BIT;
-	region.imageSubresource.mipLevel = 0;
-	region.imageSubresource.baseArrayLayer = 0;
-	region.imageSubresource.layerCount = 1;
-	region.imageOffset = {0, 0, 0};
-	region.imageExtent = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};
-	vkCmdCopyImageToBuffer((linkedRenderEngine->graphicsCommandPool)->index(commandBufferIndex)->commandBuffer, image,
-						   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, buffer->buffer, 1, &region);
-	/**@todo Needs to be done in a way that these dependencies get added.*/
+    VkBufferImageCopy region{};
+    region.bufferOffset      = 0;
+    region.bufferRowLength   = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource.aspectMask =
+      format == linkedRenderEngine->swapchain.image_format ? VK_IMAGE_ASPECT_COLOR_BIT : VK_IMAGE_ASPECT_DEPTH_BIT;
+    region.imageSubresource.mipLevel       = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount     = 1;
+    region.imageOffset                     = {0, 0, 0};
+    region.imageExtent                     = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};
+    vkCmdCopyImageToBuffer(
+      (linkedRenderEngine->graphicsCommandPool)->index(commandBufferIndex)->commandBuffer,
+      image,
+      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+      buffer->buffer,
+      1,
+      &region
+    );
+    /**@todo Needs to be done in a way that these dependencies get added.*/
 }
 
 void IEImage::transitionLayout(VkImageLayout newLayout) {
-	if (layout == newLayout) {
-		return;
-	}
-	if (newLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 "Attempt to transition to an undefined layout (VK_IMAGE_LAYOUT_UNDEFINED)!");
-		return;
-	}
-	IEImageMemoryBarrier imageMemoryBarrier{.newLayout=newLayout, .srcQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED, .dstQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED, .image=shared_from_this(), .subresourceRange={.aspectMask=aspect, .baseMipLevel=0, .levelCount=1,  // Will be used for mip mapping in the future
-			.layerCount=1}};
-	VkPipelineStageFlags sourceStage;
-	VkPipelineStageFlags destinationStage;
-	if (layout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
-		imageMemoryBarrier.srcAccessMask = 0;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-		sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-	} else if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
-		imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-		destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-	} else if ((layout == VK_IMAGE_LAYOUT_UNDEFINED) && ((newLayout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) || (newLayout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL))) {
-		imageMemoryBarrier.srcAccessMask = 0;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-		sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		destinationStage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-	} else if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
-		imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-		sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-		destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-	} else if (layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
-		imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-		destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-	} else if (layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
-		imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-		sourceStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-	} else if (layout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
-		imageMemoryBarrier.srcAccessMask = 0;
-		imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-	} else {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to transition with unknown parameters!");
-		return;
-	}
-	linkedRenderEngine->graphicsCommandPool->index(0)->recordPipelineBarrier(sourceStage, destinationStage, 0, {}, {}, {imageMemoryBarrier});
-	layout = newLayout;
+    if (layout == newLayout) return;
+    if (newLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Attempt to transition to an undefined layout (VK_IMAGE_LAYOUT_UNDEFINED)!"
+        );
+        return;
+    }
+    IEImageMemoryBarrier imageMemoryBarrier{
+      .newLayout           = newLayout,
+      .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+      .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+      .image               = shared_from_this(),
+      .subresourceRange    = {
+                              .aspectMask   = aspect,
+                              .baseMipLevel = 0,
+                              .levelCount   = 1, // Will be used for mip mapping in the future
+           .layerCount   = 1}
+    };
+    VkPipelineStageFlags sourceStage;
+    VkPipelineStageFlags destinationStage;
+    if (layout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
+        imageMemoryBarrier.srcAccessMask = 0;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        sourceStage                      = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage                 = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    } else if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        sourceStage                      = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage                 = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    } else if ((layout == VK_IMAGE_LAYOUT_UNDEFINED) && ((newLayout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) || (newLayout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL))) {
+        imageMemoryBarrier.srcAccessMask = 0;
+        imageMemoryBarrier.dstAccessMask =
+          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        sourceStage      = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    } else if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        sourceStage                      = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage                 = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    } else if (layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        sourceStage                      = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage                 = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    } else if (layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        sourceStage                      = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        destinationStage                 = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    } else if (layout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        imageMemoryBarrier.srcAccessMask = 0;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        sourceStage                      = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage                 = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    } else {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Attempt to transition with unknown parameters!"
+        );
+        return;
+    }
+    linkedRenderEngine->graphicsCommandPool->index(0)
+      ->recordPipelineBarrier(sourceStage, destinationStage, 0, {}, {}, {imageMemoryBarrier});
+    layout = newLayout;
 }
 
 void IEImage::_vulkanCreateImage() {
-	// Set up image create info.
-	VkImageCreateInfo imageCreateInfo{.sType=VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, .imageType=type, .format=format, .extent=VkExtent3D{.width=width, .height=height, .depth=1}, .mipLevels=1, // mipLevels, Unused due to no implementation of mip-mapping support yet.
-			.arrayLayers=1, .samples=static_cast<VkSampleCountFlagBits>(1), .tiling=tiling, .usage=usage, .sharingMode=VK_SHARING_MODE_EXCLUSIVE, .initialLayout=VK_IMAGE_LAYOUT_UNDEFINED,};
+    // Set up image create info.
+    VkImageCreateInfo imageCreateInfo{
+      .sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+      .imageType     = type,
+      .format        = format,
+      .extent        = VkExtent3D{.width = width, .height = height, .depth = 1},
+      .mipLevels     = 1, // mipLevels, Unused due to no implementation of mip-mapping support yet.
+      .arrayLayers   = 1,
+      .samples       = static_cast<VkSampleCountFlagBits>(1),
+      .tiling        = tiling,
+      .usage         = usage,
+      .sharingMode   = VK_SHARING_MODE_EXCLUSIVE,
+      .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
 
-	// Set up allocation create info
-	VmaAllocationCreateInfo allocationCreateInfo{.usage=allocationUsage,};
+    // Set up allocation create info
+    VmaAllocationCreateInfo allocationCreateInfo{
+      .usage = allocationUsage,
+    };
 
-	if (width * height == 0) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 "Image width * height is zero! This may cause Vulkan to fail to create the image. This may have been caused by uploading to VRAM before updating.");
-	}
+    if (width * height == 0) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Image width * height is zero! This may cause Vulkan to fail to create the image. This may have been "
+          "caused by uploading to VRAM before updating."
+        );
+    }
 
-	// Create image
-	if (vmaCreateImage(linkedRenderEngine->allocator, &imageCreateInfo, &allocationCreateInfo, &image, &allocation, nullptr) != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create image!");
-	}
+    // Create image
+    if (vmaCreateImage(linkedRenderEngine->allocator, &imageCreateInfo, &allocationCreateInfo, &image, &allocation, nullptr) != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create image!");
+    }
 }
 
 void IEImage::_vulkanCreateImageView() {
-	// Set up image view create info
-	VkImageViewCreateInfo imageViewCreateInfo{.sType=VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, .image=image, .viewType=VK_IMAGE_VIEW_TYPE_2D, /**@todo Add support for more than just 2D images.*/
-			.format=format, .components=VkComponentMapping{VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
-														   VK_COMPONENT_SWIZZLE_IDENTITY},  // Unused. All components are mapped to default data.
-			.subresourceRange=VkImageSubresourceRange{.aspectMask=aspect, .baseMipLevel=0, .levelCount=1,  // Unused. Mip-mapping is not yet implemented.
-					.baseArrayLayer=0, .layerCount=1,},};
+    // Set up image view create info
+    VkImageViewCreateInfo imageViewCreateInfo{
+      .sType    = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+      .image    = image,
+      .viewType = VK_IMAGE_VIEW_TYPE_2D, /**@todo Add support for more than just 2D images.*/
+      .format   = format,
+      .components =
+        VkComponentMapping{
+                           VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                           VK_COMPONENT_SWIZZLE_IDENTITY}, // Unused. All components are mapped to default data.
+      .subresourceRange =
+        VkImageSubresourceRange{
+                           .aspectMask     = aspect,
+                           .baseMipLevel   = 0,
+                           .levelCount     = 1,  // Unused. Mip-mapping is not yet implemented.
+          .baseArrayLayer = 0,
+                           .layerCount     = 1,
+                           },
+    };
 
-	// Create image view
-	if (vkCreateImageView(linkedRenderEngine->device.device, &imageViewCreateInfo, nullptr, &view) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create texture image view!");
-	}
+    // Create image view
+    if (vkCreateImageView(linkedRenderEngine->device.device, &imageViewCreateInfo, nullptr, &view) != VK_SUCCESS)
+        throw std::runtime_error("failed to create texture image view!");
 }
 
 uint8_t IEImage::getBytesInFormat() const {
-	switch (format) {
-		case VK_FORMAT_UNDEFINED:
-		case VK_FORMAT_MAX_ENUM:
-		default:
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-													 "Attempt to get number of bytes in pixel of format VK_FORMAT_UNDEFINED!");
-			return 0x0;
-		case VK_FORMAT_R8_UNORM:
-		case VK_FORMAT_R8_SNORM:
-		case VK_FORMAT_R8_USCALED:
-		case VK_FORMAT_R8_SSCALED:
-		case VK_FORMAT_R8_UINT:
-		case VK_FORMAT_R8_SINT:
-		case VK_FORMAT_R8_SRGB:
-		case VK_FORMAT_R4G4_UNORM_PACK8:
-			return 0x1;
-		case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
-		case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
-		case VK_FORMAT_R5G6B5_UNORM_PACK16:
-		case VK_FORMAT_B5G6R5_UNORM_PACK16:
-		case VK_FORMAT_R5G5B5A1_UNORM_PACK16:
-		case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
-		case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
-		case VK_FORMAT_R8G8_UNORM:
-		case VK_FORMAT_R8G8_SNORM:
-		case VK_FORMAT_R8G8_USCALED:
-		case VK_FORMAT_R8G8_SSCALED:
-		case VK_FORMAT_R8G8_UINT:
-		case VK_FORMAT_R8G8_SINT:
-		case VK_FORMAT_R8G8_SRGB:
-		case VK_FORMAT_R16_UNORM:
-		case VK_FORMAT_R16_SNORM:
-		case VK_FORMAT_R16_USCALED:
-		case VK_FORMAT_R16_SSCALED:
-		case VK_FORMAT_R16_UINT:
-		case VK_FORMAT_R16_SINT:
-		case VK_FORMAT_R16_SFLOAT:
-		case VK_FORMAT_D16_UNORM:
-		case VK_FORMAT_R10X6_UNORM_PACK16:
-		case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
-		case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
-			return 0x2;
-		case VK_FORMAT_R8G8B8_UNORM:
-		case VK_FORMAT_R8G8B8_SNORM:
-		case VK_FORMAT_R8G8B8_USCALED:
-		case VK_FORMAT_R8G8B8_SSCALED:
-		case VK_FORMAT_R8G8B8_UINT:
-		case VK_FORMAT_R8G8B8_SINT:
-		case VK_FORMAT_R8G8B8_SRGB:
-		case VK_FORMAT_B8G8R8_UNORM:
-		case VK_FORMAT_B8G8R8_SNORM:
-		case VK_FORMAT_B8G8R8_USCALED:
-		case VK_FORMAT_B8G8R8_SSCALED:
-		case VK_FORMAT_B8G8R8_UINT:
-		case VK_FORMAT_B8G8R8_SINT:
-		case VK_FORMAT_B8G8R8_SRGB:
-		case VK_FORMAT_D16_UNORM_S8_UINT:
-		case VK_FORMAT_D24_UNORM_S8_UINT:
-		case VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM:
-		case VK_FORMAT_G8_B8R8_2PLANE_420_UNORM:
-		case VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM:
-		case VK_FORMAT_G8_B8R8_2PLANE_422_UNORM:
-		case VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM:
-		case VK_FORMAT_G8_B8R8_2PLANE_444_UNORM:
-			return 0x3;
-		case VK_FORMAT_R8G8B8A8_UNORM:
-		case VK_FORMAT_R8G8B8A8_SNORM:
-		case VK_FORMAT_R8G8B8A8_USCALED:
-		case VK_FORMAT_R8G8B8A8_SSCALED:
-		case VK_FORMAT_R8G8B8A8_UINT:
-		case VK_FORMAT_R8G8B8A8_SINT:
-		case VK_FORMAT_R8G8B8A8_SRGB:
-		case VK_FORMAT_B8G8R8A8_UNORM:
-		case VK_FORMAT_B8G8R8A8_SNORM:
-		case VK_FORMAT_B8G8R8A8_USCALED:
-		case VK_FORMAT_B8G8R8A8_SSCALED:
-		case VK_FORMAT_B8G8R8A8_UINT:
-		case VK_FORMAT_B8G8R8A8_SINT:
-		case VK_FORMAT_B8G8R8A8_SRGB:
-		case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
-		case VK_FORMAT_A8B8G8R8_SNORM_PACK32:
-		case VK_FORMAT_A8B8G8R8_USCALED_PACK32:
-		case VK_FORMAT_A8B8G8R8_SSCALED_PACK32:
-		case VK_FORMAT_A8B8G8R8_UINT_PACK32:
-		case VK_FORMAT_A8B8G8R8_SINT_PACK32:
-		case VK_FORMAT_A8B8G8R8_SRGB_PACK32:
-		case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
-		case VK_FORMAT_A2R10G10B10_SNORM_PACK32:
-		case VK_FORMAT_A2R10G10B10_USCALED_PACK32:
-		case VK_FORMAT_A2R10G10B10_SSCALED_PACK32:
-		case VK_FORMAT_A2R10G10B10_UINT_PACK32:
-		case VK_FORMAT_A2R10G10B10_SINT_PACK32:
-		case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
-		case VK_FORMAT_A2B10G10R10_SNORM_PACK32:
-		case VK_FORMAT_A2B10G10R10_USCALED_PACK32:
-		case VK_FORMAT_A2B10G10R10_SSCALED_PACK32:
-		case VK_FORMAT_A2B10G10R10_UINT_PACK32:
-		case VK_FORMAT_A2B10G10R10_SINT_PACK32:
-		case VK_FORMAT_R16G16_UNORM:
-		case VK_FORMAT_R16G16_SNORM:
-		case VK_FORMAT_R16G16_USCALED:
-		case VK_FORMAT_R16G16_SSCALED:
-		case VK_FORMAT_R16G16_UINT:
-		case VK_FORMAT_R16G16_SINT:
-		case VK_FORMAT_R16G16_SFLOAT:
-		case VK_FORMAT_R32_UINT:
-		case VK_FORMAT_R32_SINT:
-		case VK_FORMAT_R32_SFLOAT:
-		case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
-		case VK_FORMAT_E5B9G9R9_UFLOAT_PACK32:
-		case VK_FORMAT_X8_D24_UNORM_PACK32:
-		case VK_FORMAT_D32_SFLOAT:
-		case VK_FORMAT_G8B8G8R8_422_UNORM:
-		case VK_FORMAT_B8G8R8G8_422_UNORM:
-		case VK_FORMAT_R10X6G10X6_UNORM_2PACK16:
-			return 0x4;
-		case VK_FORMAT_D32_SFLOAT_S8_UINT:
-			return 0x5;
-		case VK_FORMAT_R16G16B16_UNORM:
-		case VK_FORMAT_R16G16B16_SNORM:
-		case VK_FORMAT_R16G16B16_USCALED:
-		case VK_FORMAT_R16G16B16_SSCALED:
-		case VK_FORMAT_R16G16B16_UINT:
-		case VK_FORMAT_R16G16B16_SINT:
-		case VK_FORMAT_R16G16B16_SFLOAT:
-		case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16:
-		case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16:
-		case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16:
-		case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16:
-		case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16:
-		case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16:
-		case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16:
-		case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16:
-		case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16:
-		case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16:
-		case VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM:
-		case VK_FORMAT_G16_B16R16_2PLANE_420_UNORM:
-		case VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM:
-		case VK_FORMAT_G16_B16R16_2PLANE_422_UNORM:
-		case VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM:
-		case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16:
-		case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16:
-		case VK_FORMAT_G16_B16R16_2PLANE_444_UNORM:
-			return 0x6;
-		case VK_FORMAT_R16G16B16A16_UNORM:
-		case VK_FORMAT_R16G16B16A16_SNORM:
-		case VK_FORMAT_R16G16B16A16_USCALED:
-		case VK_FORMAT_R16G16B16A16_SSCALED:
-		case VK_FORMAT_R16G16B16A16_UINT:
-		case VK_FORMAT_R16G16B16A16_SINT:
-		case VK_FORMAT_R16G16B16A16_SFLOAT:
-		case VK_FORMAT_R32G32_UINT:
-		case VK_FORMAT_R32G32_SINT:
-		case VK_FORMAT_R32G32_SFLOAT:
-		case VK_FORMAT_R64_UINT:
-		case VK_FORMAT_R64_SINT:
-		case VK_FORMAT_R64_SFLOAT:
-		case VK_FORMAT_S8_UINT:
-		case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
-		case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
-		case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
-		case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
-		case VK_FORMAT_BC4_UNORM_BLOCK:
-		case VK_FORMAT_BC4_SNORM_BLOCK:
-		case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
-		case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
-		case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
-		case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
-		case VK_FORMAT_EAC_R11_UNORM_BLOCK:
-		case VK_FORMAT_EAC_R11_SNORM_BLOCK:
-		case VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16:
-		case VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16:
-		case VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16:
-		case VK_FORMAT_R12X4_UNORM_PACK16:
-		case VK_FORMAT_R12X4G12X4_UNORM_2PACK16:
-		case VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16:
-		case VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16:
-		case VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16:
-		case VK_FORMAT_G16B16G16R16_422_UNORM:
-		case VK_FORMAT_B16G16R16G16_422_UNORM:
-		case VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG:
-		case VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG:
-		case VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG:
-		case VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG:
-		case VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG:
-		case VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG:
-		case VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG:
-		case VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG:
-			return 0x8;
-		case VK_FORMAT_R32G32B32_UINT:
-		case VK_FORMAT_R32G32B32_SINT:
-		case VK_FORMAT_R32G32B32_SFLOAT:
-			return 0x12;
-		case VK_FORMAT_R32G32B32A32_UINT:
-		case VK_FORMAT_R32G32B32A32_SINT:
-		case VK_FORMAT_R32G32B32A32_SFLOAT:
-		case VK_FORMAT_R64G64_UINT:
-		case VK_FORMAT_R64G64_SINT:
-		case VK_FORMAT_R64G64_SFLOAT:
-		case VK_FORMAT_BC2_UNORM_BLOCK:
-		case VK_FORMAT_BC2_SRGB_BLOCK:
-		case VK_FORMAT_BC3_UNORM_BLOCK:
-		case VK_FORMAT_BC3_SRGB_BLOCK:
-		case VK_FORMAT_BC5_UNORM_BLOCK:
-		case VK_FORMAT_BC5_SNORM_BLOCK:
-		case VK_FORMAT_BC6H_UFLOAT_BLOCK:
-		case VK_FORMAT_BC6H_SFLOAT_BLOCK:
-		case VK_FORMAT_BC7_UNORM_BLOCK:
-		case VK_FORMAT_BC7_SRGB_BLOCK:
-		case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
-		case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
-		case VK_FORMAT_EAC_R11G11_UNORM_BLOCK:
-		case VK_FORMAT_EAC_R11G11_SNORM_BLOCK:
-		case VK_FORMAT_ASTC_4x4_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_4x4_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_5x4_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_5x4_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_5x5_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_5x5_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_6x5_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_6x5_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_6x6_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_6x6_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_8x5_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_8x5_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_8x6_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_8x6_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_8x8_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_8x8_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_10x5_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_10x5_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_10x6_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_10x6_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_10x8_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_10x8_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_10x10_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_10x10_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_12x10_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_12x10_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_12x12_UNORM_BLOCK:
-		case VK_FORMAT_ASTC_12x12_SRGB_BLOCK:
-		case VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK:
-		case VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK:
-			return 0x16;
-		case VK_FORMAT_R64G64B64_UINT:
-		case VK_FORMAT_R64G64B64_SINT:
-		case VK_FORMAT_R64G64B64_SFLOAT:
-			return 0x24;
-		case VK_FORMAT_R64G64B64A64_UINT:
-		case VK_FORMAT_R64G64B64A64_SINT:
-		case VK_FORMAT_R64G64B64A64_SFLOAT:
-			return 0x32;
-	}
+    switch (format) {
+        case VK_FORMAT_UNDEFINED:
+        case VK_FORMAT_MAX_ENUM:
+        default:
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+              "Attempt to get number of bytes in pixel of format VK_FORMAT_UNDEFINED!"
+            );
+            return 0x0;
+        case VK_FORMAT_R8_UNORM:
+        case VK_FORMAT_R8_SNORM:
+        case VK_FORMAT_R8_USCALED:
+        case VK_FORMAT_R8_SSCALED:
+        case VK_FORMAT_R8_UINT:
+        case VK_FORMAT_R8_SINT:
+        case VK_FORMAT_R8_SRGB:
+        case VK_FORMAT_R4G4_UNORM_PACK8: return 0x1;
+        case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
+        case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
+        case VK_FORMAT_R5G6B5_UNORM_PACK16:
+        case VK_FORMAT_B5G6R5_UNORM_PACK16:
+        case VK_FORMAT_R5G5B5A1_UNORM_PACK16:
+        case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
+        case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
+        case VK_FORMAT_R8G8_UNORM:
+        case VK_FORMAT_R8G8_SNORM:
+        case VK_FORMAT_R8G8_USCALED:
+        case VK_FORMAT_R8G8_SSCALED:
+        case VK_FORMAT_R8G8_UINT:
+        case VK_FORMAT_R8G8_SINT:
+        case VK_FORMAT_R8G8_SRGB:
+        case VK_FORMAT_R16_UNORM:
+        case VK_FORMAT_R16_SNORM:
+        case VK_FORMAT_R16_USCALED:
+        case VK_FORMAT_R16_SSCALED:
+        case VK_FORMAT_R16_UINT:
+        case VK_FORMAT_R16_SINT:
+        case VK_FORMAT_R16_SFLOAT:
+        case VK_FORMAT_D16_UNORM:
+        case VK_FORMAT_R10X6_UNORM_PACK16:
+        case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
+        case VK_FORMAT_A4B4G4R4_UNORM_PACK16: return 0x2;
+        case VK_FORMAT_R8G8B8_UNORM:
+        case VK_FORMAT_R8G8B8_SNORM:
+        case VK_FORMAT_R8G8B8_USCALED:
+        case VK_FORMAT_R8G8B8_SSCALED:
+        case VK_FORMAT_R8G8B8_UINT:
+        case VK_FORMAT_R8G8B8_SINT:
+        case VK_FORMAT_R8G8B8_SRGB:
+        case VK_FORMAT_B8G8R8_UNORM:
+        case VK_FORMAT_B8G8R8_SNORM:
+        case VK_FORMAT_B8G8R8_USCALED:
+        case VK_FORMAT_B8G8R8_SSCALED:
+        case VK_FORMAT_B8G8R8_UINT:
+        case VK_FORMAT_B8G8R8_SINT:
+        case VK_FORMAT_B8G8R8_SRGB:
+        case VK_FORMAT_D16_UNORM_S8_UINT:
+        case VK_FORMAT_D24_UNORM_S8_UINT:
+        case VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM:
+        case VK_FORMAT_G8_B8R8_2PLANE_420_UNORM:
+        case VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM:
+        case VK_FORMAT_G8_B8R8_2PLANE_422_UNORM:
+        case VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM:
+        case VK_FORMAT_G8_B8R8_2PLANE_444_UNORM: return 0x3;
+        case VK_FORMAT_R8G8B8A8_UNORM:
+        case VK_FORMAT_R8G8B8A8_SNORM:
+        case VK_FORMAT_R8G8B8A8_USCALED:
+        case VK_FORMAT_R8G8B8A8_SSCALED:
+        case VK_FORMAT_R8G8B8A8_UINT:
+        case VK_FORMAT_R8G8B8A8_SINT:
+        case VK_FORMAT_R8G8B8A8_SRGB:
+        case VK_FORMAT_B8G8R8A8_UNORM:
+        case VK_FORMAT_B8G8R8A8_SNORM:
+        case VK_FORMAT_B8G8R8A8_USCALED:
+        case VK_FORMAT_B8G8R8A8_SSCALED:
+        case VK_FORMAT_B8G8R8A8_UINT:
+        case VK_FORMAT_B8G8R8A8_SINT:
+        case VK_FORMAT_B8G8R8A8_SRGB:
+        case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
+        case VK_FORMAT_A8B8G8R8_SNORM_PACK32:
+        case VK_FORMAT_A8B8G8R8_USCALED_PACK32:
+        case VK_FORMAT_A8B8G8R8_SSCALED_PACK32:
+        case VK_FORMAT_A8B8G8R8_UINT_PACK32:
+        case VK_FORMAT_A8B8G8R8_SINT_PACK32:
+        case VK_FORMAT_A8B8G8R8_SRGB_PACK32:
+        case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+        case VK_FORMAT_A2R10G10B10_SNORM_PACK32:
+        case VK_FORMAT_A2R10G10B10_USCALED_PACK32:
+        case VK_FORMAT_A2R10G10B10_SSCALED_PACK32:
+        case VK_FORMAT_A2R10G10B10_UINT_PACK32:
+        case VK_FORMAT_A2R10G10B10_SINT_PACK32:
+        case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
+        case VK_FORMAT_A2B10G10R10_SNORM_PACK32:
+        case VK_FORMAT_A2B10G10R10_USCALED_PACK32:
+        case VK_FORMAT_A2B10G10R10_SSCALED_PACK32:
+        case VK_FORMAT_A2B10G10R10_UINT_PACK32:
+        case VK_FORMAT_A2B10G10R10_SINT_PACK32:
+        case VK_FORMAT_R16G16_UNORM:
+        case VK_FORMAT_R16G16_SNORM:
+        case VK_FORMAT_R16G16_USCALED:
+        case VK_FORMAT_R16G16_SSCALED:
+        case VK_FORMAT_R16G16_UINT:
+        case VK_FORMAT_R16G16_SINT:
+        case VK_FORMAT_R16G16_SFLOAT:
+        case VK_FORMAT_R32_UINT:
+        case VK_FORMAT_R32_SINT:
+        case VK_FORMAT_R32_SFLOAT:
+        case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
+        case VK_FORMAT_E5B9G9R9_UFLOAT_PACK32:
+        case VK_FORMAT_X8_D24_UNORM_PACK32:
+        case VK_FORMAT_D32_SFLOAT:
+        case VK_FORMAT_G8B8G8R8_422_UNORM:
+        case VK_FORMAT_B8G8R8G8_422_UNORM:
+        case VK_FORMAT_R10X6G10X6_UNORM_2PACK16: return 0x4;
+        case VK_FORMAT_D32_SFLOAT_S8_UINT: return 0x5;
+        case VK_FORMAT_R16G16B16_UNORM:
+        case VK_FORMAT_R16G16B16_SNORM:
+        case VK_FORMAT_R16G16B16_USCALED:
+        case VK_FORMAT_R16G16B16_SSCALED:
+        case VK_FORMAT_R16G16B16_UINT:
+        case VK_FORMAT_R16G16B16_SINT:
+        case VK_FORMAT_R16G16B16_SFLOAT:
+        case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16:
+        case VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM:
+        case VK_FORMAT_G16_B16R16_2PLANE_420_UNORM:
+        case VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM:
+        case VK_FORMAT_G16_B16R16_2PLANE_422_UNORM:
+        case VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM:
+        case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16:
+        case VK_FORMAT_G16_B16R16_2PLANE_444_UNORM: return 0x6;
+        case VK_FORMAT_R16G16B16A16_UNORM:
+        case VK_FORMAT_R16G16B16A16_SNORM:
+        case VK_FORMAT_R16G16B16A16_USCALED:
+        case VK_FORMAT_R16G16B16A16_SSCALED:
+        case VK_FORMAT_R16G16B16A16_UINT:
+        case VK_FORMAT_R16G16B16A16_SINT:
+        case VK_FORMAT_R16G16B16A16_SFLOAT:
+        case VK_FORMAT_R32G32_UINT:
+        case VK_FORMAT_R32G32_SINT:
+        case VK_FORMAT_R32G32_SFLOAT:
+        case VK_FORMAT_R64_UINT:
+        case VK_FORMAT_R64_SINT:
+        case VK_FORMAT_R64_SFLOAT:
+        case VK_FORMAT_S8_UINT:
+        case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
+        case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+        case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+        case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
+        case VK_FORMAT_BC4_UNORM_BLOCK:
+        case VK_FORMAT_BC4_SNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
+        case VK_FORMAT_EAC_R11_UNORM_BLOCK:
+        case VK_FORMAT_EAC_R11_SNORM_BLOCK:
+        case VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16:
+        case VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16:
+        case VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16:
+        case VK_FORMAT_R12X4_UNORM_PACK16:
+        case VK_FORMAT_R12X4G12X4_UNORM_2PACK16:
+        case VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16:
+        case VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16:
+        case VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16:
+        case VK_FORMAT_G16B16G16R16_422_UNORM:
+        case VK_FORMAT_B16G16R16G16_422_UNORM:
+        case VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG:
+        case VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG:
+        case VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG:
+        case VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG: return 0x8;
+        case VK_FORMAT_R32G32B32_UINT:
+        case VK_FORMAT_R32G32B32_SINT:
+        case VK_FORMAT_R32G32B32_SFLOAT: return 0x12;
+        case VK_FORMAT_R32G32B32A32_UINT:
+        case VK_FORMAT_R32G32B32A32_SINT:
+        case VK_FORMAT_R32G32B32A32_SFLOAT:
+        case VK_FORMAT_R64G64_UINT:
+        case VK_FORMAT_R64G64_SINT:
+        case VK_FORMAT_R64G64_SFLOAT:
+        case VK_FORMAT_BC2_UNORM_BLOCK:
+        case VK_FORMAT_BC2_SRGB_BLOCK:
+        case VK_FORMAT_BC3_UNORM_BLOCK:
+        case VK_FORMAT_BC3_SRGB_BLOCK:
+        case VK_FORMAT_BC5_UNORM_BLOCK:
+        case VK_FORMAT_BC5_SNORM_BLOCK:
+        case VK_FORMAT_BC6H_UFLOAT_BLOCK:
+        case VK_FORMAT_BC6H_SFLOAT_BLOCK:
+        case VK_FORMAT_BC7_UNORM_BLOCK:
+        case VK_FORMAT_BC7_SRGB_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
+        case VK_FORMAT_EAC_R11G11_UNORM_BLOCK:
+        case VK_FORMAT_EAC_R11G11_SNORM_BLOCK:
+        case VK_FORMAT_ASTC_4x4_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_4x4_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_5x4_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_5x4_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_5x5_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_5x5_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_6x5_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_6x5_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_6x6_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_6x6_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_8x5_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_8x5_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_8x6_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_8x6_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_8x8_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_8x8_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_10x5_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_10x5_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_10x6_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_10x6_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_10x8_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_10x8_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_10x10_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_10x10_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_12x10_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_12x10_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_12x12_UNORM_BLOCK:
+        case VK_FORMAT_ASTC_12x12_SRGB_BLOCK:
+        case VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK:
+        case VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK: return 0x16;
+        case VK_FORMAT_R64G64B64_UINT:
+        case VK_FORMAT_R64G64B64_SINT:
+        case VK_FORMAT_R64G64B64_SFLOAT: return 0x24;
+        case VK_FORMAT_R64G64B64A64_UINT:
+        case VK_FORMAT_R64G64B64A64_SINT:
+        case VK_FORMAT_R64G64B64A64_SFLOAT: return 0x32;
+    }
 }

--- a/src/GraphicsModule/Image/IEImage.hpp
+++ b/src/GraphicsModule/Image/IEImage.hpp
@@ -11,173 +11,170 @@ class IEBuffer;
 #include "IEAPI.hpp"
 
 #define GLEW_IMPLEMENTATION
+
 #include <include/GL/glew.h>
 
 // External dependencies
 #include <include/vk_mem_alloc.h>
-
-#include <vulkan/vulkan.h>
-
 #include <stb_image.h>
+#include <vulkan/vulkan.h>
 
 // System dependencies
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
-#include <functional>
-
 
 enum IEImageStatus {
-	IE_IMAGE_STATUS_UNKNOWN = 0x0,
-	IE_IMAGE_STATUS_UNLOADED = 0x1,
-	IE_IMAGE_STATUS_LOADED = 0x2,
-	IE_IMAGE_STATUS_QUEUED_RAM = 0x4,
-	IE_IMAGE_STATUS_IN_RAM = 0x8,
-	IE_IMAGE_STATUS_QUEUED_VRAM = 0x10,
-	IE_IMAGE_STATUS_IN_VRAM = 0x11,
+    IE_IMAGE_STATUS_UNKNOWN     = 0x0,
+    IE_IMAGE_STATUS_UNLOADED    = 0x1,
+    IE_IMAGE_STATUS_LOADED      = 0x2,
+    IE_IMAGE_STATUS_QUEUED_RAM  = 0x4,
+    IE_IMAGE_STATUS_IN_RAM      = 0x8,
+    IE_IMAGE_STATUS_QUEUED_VRAM = 0x10,
+    IE_IMAGE_STATUS_IN_VRAM     = 0x11,
 };
-
 
 class IEImage : public IEDependency, public std::enable_shared_from_this<IEImage> {
 protected:
-	[[nodiscard]] uint8_t getHighestMSAASampleCount(uint8_t requested) const;
+    [[nodiscard]] uint8_t getHighestMSAASampleCount(uint8_t requested) const;
 
-	[[nodiscard]] float getHighestAnisotropyLevel(float requested) const;
+    [[nodiscard]] float getHighestAnisotropyLevel(float requested) const;
 
 public:
-	struct CreateInfo {
-		VkFormat format{VK_FORMAT_R8G8B8A8_SRGB};
-		VkImageLayout layout{VK_IMAGE_LAYOUT_UNDEFINED};
-		VkImageType type{VK_IMAGE_TYPE_2D};
-		VkImageUsageFlags usage{VK_IMAGE_USAGE_SAMPLED_BIT};
-		VkImageCreateFlags flags{};
-		VkImageAspectFlags aspect{VK_IMAGE_ASPECT_COLOR_BIT};
-		VmaMemoryUsage allocationUsage{};
-		uint32_t width{}, height{}, channels{};
-		std::vector<char> data{};
-	};
+    struct CreateInfo {
+        VkFormat           format{VK_FORMAT_R8G8B8A8_SRGB};
+        VkImageLayout      layout{VK_IMAGE_LAYOUT_UNDEFINED};
+        VkImageType        type{VK_IMAGE_TYPE_2D};
+        VkImageUsageFlags  usage{VK_IMAGE_USAGE_SAMPLED_BIT};
+        VkImageCreateFlags flags{};
+        VkImageAspectFlags aspect{VK_IMAGE_ASPECT_COLOR_BIT};
+        VmaMemoryUsage     allocationUsage{};
+        uint32_t           width{}, height{}, channels{};
+        std::vector<char>  data{};
+    };
 
-	VkImage image{};
-	VkImageView view{};
-	VkSampler sampler{};
-	/**@todo Add proper format checks.*/
-	VkFormat format{VK_FORMAT_R8G8B8A8_SRGB};  // Image format as interpreted by the Vulkan API
-	VkImageLayout layout{VK_IMAGE_LAYOUT_UNDEFINED};  // How the GPU sees the image
-	VkImageType type{VK_IMAGE_TYPE_2D};  // Image shape (1D, 2D, 3D)
-	VkImageTiling tiling{VK_IMAGE_TILING_OPTIMAL};  // How the image is stored in GPU memory
-	VkImageUsageFlags usage{VK_IMAGE_USAGE_SAMPLED_BIT};  // How the program is going to use the image
-	VkImageCreateFlags flags{};  // How should / was the image be created
-	VkImageAspectFlags aspect{VK_IMAGE_ASPECT_COLOR_BIT};
-	VmaMemoryUsage allocationUsage{};  // How is the allocation going to be used between the CPU and GPU
-	VmaAllocation allocation{};
-	uint32_t width{};
-	uint32_t height{};
-	uint32_t channels{};
-	IERenderEngine *linkedRenderEngine{};
-	std::vector<char> data{};
-	IEImageStatus status{IE_IMAGE_STATUS_UNKNOWN};
-	GLuint id{};
+    VkImage            image{};
+    VkImageView        view{};
+    VkSampler          sampler{};
+    /**@todo Add proper format checks.*/
+    VkFormat           format{VK_FORMAT_R8G8B8A8_SRGB};    // Image format as interpreted by the Vulkan API
+    VkImageLayout      layout{VK_IMAGE_LAYOUT_UNDEFINED};  // How the GPU sees the image
+    VkImageType        type{VK_IMAGE_TYPE_2D};             // Image shape (1D, 2D, 3D)
+    VkImageTiling      tiling{VK_IMAGE_TILING_OPTIMAL};    // How the image is stored in GPU memory
+    VkImageUsageFlags  usage{VK_IMAGE_USAGE_SAMPLED_BIT};  // How the program is going to use the image
+    VkImageCreateFlags flags{};                            // How should / was the image be created
+    VkImageAspectFlags aspect{VK_IMAGE_ASPECT_COLOR_BIT};
+    VmaMemoryUsage     allocationUsage{};  // How is the allocation going to be used between the CPU and GPU
+    VmaAllocation      allocation{};
+    uint32_t           width{};
+    uint32_t           height{};
+    uint32_t           channels{};
+    IERenderEngine    *linkedRenderEngine{};
+    std::vector<char>  data{};
+    IEImageStatus      status{IE_IMAGE_STATUS_UNKNOWN};
+    GLuint             id{};
 
-	IEImage() = default;
+    IEImage() = default;
 
-	IEImage(IERenderEngine *, IEImage::CreateInfo *);
+    IEImage(IERenderEngine *, IEImage::CreateInfo *);
 
-	~IEImage() override;
+    ~IEImage() override;
 
-	static void setAPI(const IEAPI &API);
+    static void setAPI(const IEAPI &API);
 
 
-	void create(IERenderEngine *, IEImage::CreateInfo *);
+    void create(IERenderEngine *, IEImage::CreateInfo *);
 
 private:
-	static std::function<void(IEImage &)> _uploadToRAM;
+    static std::function<void(IEImage &)> _uploadToRAM;
 
-	static std::function<void(IEImage &)> _uploadToVRAM;
-	static std::function<void(IEImage &, const std::vector<char> &)> _uploadToVRAM_vector;
-	static std::function<void(IEImage &, void *, size_t)> _uploadToVRAM_void;
+    static std::function<void(IEImage &)>                            _uploadToVRAM;
+    static std::function<void(IEImage &, const std::vector<char> &)> _uploadToVRAM_vector;
+    static std::function<void(IEImage &, void *, size_t)>            _uploadToVRAM_void;
 
-	static std::function<void(IEImage &, const std::vector<char> &)> _update_vector;
-	static std::function<void(IEImage &, void *, size_t)> _update_void;
+    static std::function<void(IEImage &, const std::vector<char> &)> _update_vector;
+    static std::function<void(IEImage &, void *, size_t)>            _update_void;
 
-	static std::function<void(IEImage &)> _unloadFromVRAM;
+    static std::function<void(IEImage &)> _unloadFromVRAM;
 
-	static std::function<void(IEImage &)> _destroy;
+    static std::function<void(IEImage &)> _destroy;
 
 protected:
-	virtual void _openglUploadToRAM();
+    virtual void _openglUploadToRAM();
 
-	virtual void _vulkanUploadToRAM();
-
-
-	virtual void _openglUploadToVRAM();
-
-	virtual void _vulkanUploadToVRAM();
-
-	virtual void _openglUploadToVRAM_vector(const std::vector<char> &);
-
-	virtual void _vulkanUploadToVRAM_vector(const std::vector<char> &);
-
-	virtual void _openglUploadToVRAM_void(void *, size_t);
-
-	virtual void _vulkanUploadToVRAM_void(void *, size_t);
+    virtual void _vulkanUploadToRAM();
 
 
-	virtual void _openglUpdate_vector(const std::vector<char> &);
+    virtual void _openglUploadToVRAM();
 
-	virtual void _vulkanUpdate_vector(const std::vector<char> &);
+    virtual void _vulkanUploadToVRAM();
 
-	virtual void _openglUpdate_voidPtr(void *, size_t);
+    virtual void _openglUploadToVRAM_vector(const std::vector<char> &);
 
-	virtual void _vulkanUpdate_voidPtr(void *, size_t);
+    virtual void _vulkanUploadToVRAM_vector(const std::vector<char> &);
 
+    virtual void _openglUploadToVRAM_void(void *, size_t);
 
-	virtual void _openglUnloadFromVRAM();
-
-	virtual void _vulkanUnloadFromVRAM();
-
-
-	virtual void _openglDestroy();
-
-	virtual void _vulkanDestroy();
+    virtual void _vulkanUploadToVRAM_void(void *, size_t);
 
 
-	virtual void _vulkanCreateImage();
+    virtual void _openglUpdate_vector(const std::vector<char> &);
 
-	virtual void _vulkanCreateImageView();
+    virtual void _vulkanUpdate_vector(const std::vector<char> &);
+
+    virtual void _openglUpdate_voidPtr(void *, size_t);
+
+    virtual void _vulkanUpdate_voidPtr(void *, size_t);
+
+
+    virtual void _openglUnloadFromVRAM();
+
+    virtual void _vulkanUnloadFromVRAM();
+
+
+    virtual void _openglDestroy();
+
+    virtual void _vulkanDestroy();
+
+
+    virtual void _vulkanCreateImage();
+
+    virtual void _vulkanCreateImageView();
 
 public:
-	void uploadToRAM();
+    void uploadToRAM();
 
-	void uploadToRAM(const std::vector<char> &);
+    void uploadToRAM(const std::vector<char> &);
 
-	void uploadToRAM(void *, size_t);
-
-
-	virtual void uploadToVRAM();
-
-	void uploadToVRAM(const std::vector<char> &);
-
-	void uploadToVRAM(void *, size_t);
+    void uploadToRAM(void *, size_t);
 
 
-	void update(const std::vector<char> &);
+    virtual void uploadToVRAM();
 
-	void update(void *data, size_t size);
+    void uploadToVRAM(const std::vector<char> &);
 
-
-	void unloadFromVRAM();
-
-
-	void destroy();
+    void uploadToVRAM(void *, size_t);
 
 
-	void toBuffer(const std::shared_ptr<IEBuffer> &, uint32_t) const;
+    void update(const std::vector<char> &);
+
+    void update(void *data, size_t size);
 
 
-	// VULKAN ONLY FUNCTIONS
+    void unloadFromVRAM();
 
 
-	uint8_t getBytesInFormat() const;
+    void destroy();
 
-	void transitionLayout(VkImageLayout);
+
+    void toBuffer(const std::shared_ptr<IEBuffer> &, uint32_t) const;
+
+
+    // VULKAN ONLY FUNCTIONS
+
+
+    uint8_t getBytesInFormat() const;
+
+    void transitionLayout(VkImageLayout);
 };

--- a/src/GraphicsModule/Image/IEImageNEW.cpp
+++ b/src/GraphicsModule/Image/IEImageNEW.cpp
@@ -1,96 +1,92 @@
 #include "IEImageNEW.hpp"
+
 #include <iostream>
 
 constexpr IEImageLocation operator|(IEImageLocation first, IEImageLocation second) noexcept {
-	return (IEImageLocation) ((uint8_t) first | (uint8_t) second);
+    return (IEImageLocation) ((uint8_t) first | (uint8_t) second);
 }
 
 constexpr IEImageLocation operator&(IEImageLocation first, IEImageLocation second) noexcept {
-	return (IEImageLocation) ((uint8_t) first & (uint8_t) second);
+    return (IEImageLocation) ((uint8_t) first & (uint8_t) second);
 }
 
 constexpr IEImageLocation operator^(IEImageLocation first, IEImageLocation second) noexcept {
-	return (IEImageLocation) ((uint8_t) first ^ (uint8_t) second);
+    return (IEImageLocation) ((uint8_t) first ^ (uint8_t) second);
 }
 
 constexpr IEImageLocation operator~(IEImageLocation first) noexcept {
-	return (IEImageLocation) (~(uint8_t) first);
+    return (IEImageLocation) (~(uint8_t) first);
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 IEImageNEW<width, height, channels>::IEImageNEW(IEImageNEW<0, 0, 0> &t_image) :
-		size{t_image.getSize()},
-		location{t_image.getLocation()},
-		data{} {
-	if (t_image.getSize() != size || t_image.getWidth() != width || t_image.getHeight() != height || t_image.getChannels() != channels) {
-		// Resize image
-		size = width * height * channels;
-	}
-	if (data != nullptr && t_image.getData() != nullptr) {
-		for (size_t i = 0; i < std::min(size, t_image.getSize()); ++i) {
-			data->at(i) = t_image.getData()->at(i);
-		}
-	}
+        size{t_image.getSize()},
+        location{t_image.getLocation()},
+        data{} {
+    if (t_image.getSize() != size || t_image.getWidth() != width || t_image.getHeight() != height || t_image.getChannels() != channels) {
+        // Resize image
+        size = width * height * channels;
+    }
+    if (data != nullptr && t_image.getData() != nullptr)
+        for (size_t i = 0; i < std::min(size, t_image.getSize()); ++i) data->at(i) = t_image.getData()->at(i);
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 void IEImageNEW<width, height, channels>::setLocation(IEImageLocation) {
-	std::cout << getWidth() << '\n';
+    std::cout << getWidth() << '\n';
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 uint32_t IEImageNEW<width, height, channels>::getWidth() const {
-	return width;
+    return width;
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 uint32_t IEImageNEW<width, height, channels>::getHeight() const {
-	return height;
+    return height;
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 uint8_t IEImageNEW<width, height, channels>::getChannels() const {
-	return channels;
+    return channels;
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 std::array<char, width * height * channels> *IEImageNEW<width, height, channels>::getData() const {
-	return data;
+    return data;
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 size_t IEImageNEW<width, height, channels>::getSize() const {
-	return size;
+    return size;
 }
 
 template<uint32_t width, uint32_t height, uint8_t channels>
 IEImageLocation IEImageNEW<width, height, channels>::getLocation() const {
-	return location;
+    return location;
 }
 
 /* Specializations for the dynamically resizable image */
 void IEImageNEW<0, 0, 0>::setDimensions(uint32_t t_width, uint32_t t_height, uint8_t t_channels) {
-	width = t_width;
-	height = t_height;
-	channels = t_channels;
-	size = width * height * channels;
-	if (location & IE_IMAGE_LOCATION_SYSTEM && data != nullptr) {
-		data->resize(size);
-	}
+    width    = t_width;
+    height   = t_height;
+    channels = t_channels;
+    size     = width * height * channels;
+    if (location & IE_IMAGE_LOCATION_SYSTEM && data != nullptr) data->resize(size);
 }
 
 uint32_t IEImageNEW<0, 0, 0>::getWidth() const {
-	return width;
+    return width;
 }
 
 uint32_t IEImageNEW<0, 0, 0>::getHeight() const {
-	return height;
+    return height;
 }
 
 uint8_t IEImageNEW<0, 0, 0>::getChannels() const {
-	return channels;
+    return channels;
 }
 
 std::vector<char> *IEImageNEW<0, 0, 0>::getData() const {
-	return data;
+    return data;
 }

--- a/src/GraphicsModule/Image/IEImageNEW.hpp
+++ b/src/GraphicsModule/Image/IEImageNEW.hpp
@@ -1,16 +1,17 @@
 #pragma once
 
-#include <cstdint>
-#include <mutex>
-#include <cassert>
-#include <vector>
 #include "stb_image.h"
 
+#include <cassert>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
 enum IEImageLocation {
-	IE_IMAGE_LOCATION_NULL = 0x0,
-	IE_IMAGE_LOCATION_NONE = 0x1,
-	IE_IMAGE_LOCATION_SYSTEM = 0x2,
-	IE_IMAGE_LOCATION_VIDEO = 0x4
+    IE_IMAGE_LOCATION_NULL   = 0x0,
+    IE_IMAGE_LOCATION_NONE   = 0x1,
+    IE_IMAGE_LOCATION_SYSTEM = 0x2,
+    IE_IMAGE_LOCATION_VIDEO  = 0x4
 };
 
 
@@ -19,70 +20,69 @@ class aiTexture;
 template<uint32_t width = 0, uint32_t height = 0, uint8_t channels = 0>
 class IEImageNEW {
 public:
-	std::size_t size;
-	IEImageLocation location;
-	std::array<char, width * height * channels> *data;
+    std::size_t                                  size;
+    IEImageLocation                              location;
+    std::array<char, width * height * channels> *data;
 
 public:
-	IEImageNEW() :
-			size{width * height * channels},
-			location{IE_IMAGE_LOCATION_NONE},
-			data{} {}
+    IEImageNEW() : size{width * height * channels}, location{IE_IMAGE_LOCATION_NONE}, data{} {
+    }
 
-	/** Copy a dynamically sized image into this statically sized image. */
-	explicit IEImageNEW(IEImageNEW<0, 0, 0> &);
+    /** Copy a dynamically sized image into this statically sized image. */
+    explicit IEImageNEW(IEImageNEW<0, 0, 0> &);
 
-	/** Change the location(s) that the image is stored in.*/
-	virtual void setLocation(IEImageLocation);
+    /** Change the location(s) that the image is stored in.*/
+    virtual void setLocation(IEImageLocation);
 
-	/** Load assimp image data into the currently set location(s).*/
-	virtual void uploadTexture(const aiTexture *) {};
+    /** Load assimp image data into the currently set location(s).*/
+    virtual void uploadTexture(const aiTexture *){};
 
-	/** Load stb_image data of size 'size' into the currently set location(s). */
-	virtual void uploadTexture(stbi_uc *) {};
+    /** Load stb_image data of size 'size' into the currently set location(s). */
+    virtual void uploadTexture(stbi_uc *){};
 
-	/** Load data into the currently set location(s). */
-	virtual void uploadData(std::array<char, width * height * channels> *) {};
+    /** Load data into the currently set location(s). */
+    virtual void uploadData(std::array<char, width * height * channels> *){};
 
-	// Getters for the image attributes. The width, height, and channels must be virtual to allow the specialized type to override them.
+    // Getters for the image attributes. The width, height, and channels must be virtual to allow the specialized
+    // type to override them.
 
-	[[nodiscard]] virtual uint32_t getWidth() const;
+    [[nodiscard]] virtual uint32_t getWidth() const;
 
-	[[nodiscard]] virtual uint32_t getHeight() const;
+    [[nodiscard]] virtual uint32_t getHeight() const;
 
-	[[nodiscard]] virtual uint8_t getChannels() const;
+    [[nodiscard]] virtual uint8_t getChannels() const;
 
-	[[nodiscard]] std::array<char, width * height * channels> *getData() const;
+    [[nodiscard]] std::array<char, width * height * channels> *getData() const;
 
-	[[nodiscard]] size_t getSize() const;
+    [[nodiscard]] size_t getSize() const;
 
-	[[nodiscard]] IEImageLocation getLocation() const;
+    [[nodiscard]] IEImageLocation getLocation() const;
 };
 
 template<>
 class IEImageNEW<0, 0, 0> : public IEImageNEW<1, 1, 1> {
 public:
-	using IEImageNEW<1, 1, 1>::uploadTexture;
-	using IEImageNEW<1, 1, 1>::setLocation;
-	using IEImageNEW<1, 1, 1>::getSize;
-	using IEImageNEW<1, 1, 1>::getLocation;
+    using IEImageNEW<1, 1, 1>::uploadTexture;
+    using IEImageNEW<1, 1, 1>::setLocation;
+    using IEImageNEW<1, 1, 1>::getSize;
+    using IEImageNEW<1, 1, 1>::getLocation;
 
-	virtual void setDimensions(uint32_t, uint32_t, uint8_t);
+    virtual void setDimensions(uint32_t, uint32_t, uint8_t);
 
-	virtual void uploadData(std::vector<char> *) {};
+    virtual void uploadData(std::vector<char> *){};
 
-	[[nodiscard]] uint32_t getWidth() const override;
+    [[nodiscard]] uint32_t getWidth() const override;
 
-	[[nodiscard]] uint32_t getHeight() const override;
+    [[nodiscard]] uint32_t getHeight() const override;
 
-	[[nodiscard]] uint8_t getChannels() const override;
+    [[nodiscard]] uint8_t getChannels() const override;
 
-	// Must not be made virtual. It must hide the previous getData().
-	[[nodiscard]] std::vector<char> *getData() const;
+    // Must not be made virtual. It must hide the previous getData().
+    [[nodiscard]] std::vector<char> *getData() const;
 
 private:
-	uint32_t width{};
-	uint32_t height{};
-	uint8_t channels{};
-	std::vector<char> *data{};
+    uint32_t           width{};
+    uint32_t           height{};
+    uint8_t            channels{};
+    std::vector<char> *data{};
 };

--- a/src/GraphicsModule/Image/IENDimensionalResizableImage.cpp
+++ b/src/GraphicsModule/Image/IENDimensionalResizableImage.cpp
@@ -1,29 +1,29 @@
 #include "IENDimensionalResizableImage.hpp"
 
 char *IENDimensionalResizableImage::getData() const {
-	return m_data;
+    return m_data;
 }
 
 size_t IENDimensionalResizableImage::getSize() const {
-	return m_size;
+    return m_size;
 }
 
 size_t *IENDimensionalResizableImage::getDimensions() const {
-	return m_dimensions;
+    return m_dimensions;
 }
 
 size_t IENDimensionalResizableImage::getDimensionCount() const {
-	return m_dimensionCount;
+    return m_dimensionCount;
 }
 
 size_t IENDimensionalResizableImage::getChannels() const {
-	return m_channels;
+    return m_channels;
 }
 
 IEImageLocation IENDimensionalResizableImage::getLocation() const {
-	return m_location;
+    return m_location;
 }
 
 void IENDimensionalResizableImage::setLocation(IEImageLocation t_location) {
-	m_location = t_location;
+    m_location = t_location;
 }

--- a/src/GraphicsModule/Image/IENDimensionalResizableImage.hpp
+++ b/src/GraphicsModule/Image/IENDimensionalResizableImage.hpp
@@ -1,72 +1,69 @@
 #pragma once
 
-#include <vector>
 #include <cstdint>
-#include <typeinfo>
 #include <stdexcept>
+#include <typeinfo>
+#include <vector>
 
 typedef enum IEImageLocation {
-	IE_IMAGE_LOCATION_NULL = 0x0,
-	IE_IMAGE_LOCATION_NONE = 0x1,
-	IE_IMAGE_LOCATION_SYSTEM = 0x2,
-	IE_IMAGE_LOCATION_VIDEO = 0x4
+    IE_IMAGE_LOCATION_NULL   = 0x0,
+    IE_IMAGE_LOCATION_NONE   = 0x1,
+    IE_IMAGE_LOCATION_SYSTEM = 0x2,
+    IE_IMAGE_LOCATION_VIDEO  = 0x4
 } IEImageLocation;
 
 constexpr IEImageLocation operator|(IEImageLocation first, IEImageLocation second) noexcept {
-	uint8_t result = (uint8_t) first | (uint8_t) second;
-	if (result & IE_IMAGE_LOCATION_NONE && (result & ~IE_IMAGE_LOCATION_NONE) > IE_IMAGE_LOCATION_NULL) {
-		std::logic_error("IE_IMAGE_LOCATION_NONE mix error!");
-	}
-	return (IEImageLocation) result;
+    uint8_t result = (uint8_t) first | (uint8_t) second;
+    if (result & IE_IMAGE_LOCATION_NONE && (result & ~IE_IMAGE_LOCATION_NONE) > IE_IMAGE_LOCATION_NULL)
+        std::logic_error("IE_IMAGE_LOCATION_NONE mix error!");
+    return (IEImageLocation) result;
 }
 
 constexpr IEImageLocation operator&(IEImageLocation first, IEImageLocation second) noexcept {
-	return (IEImageLocation) ((uint8_t) first & (uint8_t) second);
+    return (IEImageLocation) ((uint8_t) first & (uint8_t) second);
 }
 
 constexpr IEImageLocation operator^(IEImageLocation first, IEImageLocation second) noexcept {
-	return (IEImageLocation) ((uint8_t) first ^ (uint8_t) second);
+    return (IEImageLocation) ((uint8_t) first ^ (uint8_t) second);
 }
 
 constexpr IEImageLocation operator~(IEImageLocation first) noexcept {
-	return (IEImageLocation) (~(uint8_t) first);
+    return (IEImageLocation) (~(uint8_t) first);
 }
-
 
 class IENDimensionalResizableImage {
 private:
-	char *m_data;
-	size_t m_size;
-	size_t *m_dimensions;
-	size_t m_dimensionCount;
-	size_t m_channels;
-	IEImageLocation m_location;
+    char           *m_data;
+    size_t          m_size;
+    size_t         *m_dimensions;
+    size_t          m_dimensionCount;
+    size_t          m_channels;
+    IEImageLocation m_location;
 
 public:
-	template<typename... Args>
-	explicit IENDimensionalResizableImage(size_t t_channels, Args... t_dimensions) :
-			m_data{nullptr},
-			m_size{1},
-			m_dimensionCount{sizeof...(t_dimensions)},
-			m_channels{t_channels},
-			m_location{IE_IMAGE_LOCATION_SYSTEM} {
-		((m_size *= t_dimensions), ...);
-		m_dimensions = new size_t[m_dimensionCount];
-		if (m_dimensionCount == 0) m_size = 0;
-	}
+    template<typename... Args>
+    explicit IENDimensionalResizableImage(size_t t_channels, Args... t_dimensions) :
+            m_data{nullptr},
+            m_size{1},
+            m_dimensionCount{sizeof...(t_dimensions)},
+            m_channels{t_channels},
+            m_location{IE_IMAGE_LOCATION_SYSTEM} {
+        ((m_size *= t_dimensions), ...);
+        m_dimensions = new size_t[m_dimensionCount];
+        if (m_dimensionCount == 0) m_size = 0;
+    }
 
-	[[nodiscard]] char *getData() const;
+    [[nodiscard]] char *getData() const;
 
-	[[nodiscard]] size_t getSize() const;
+    [[nodiscard]] size_t getSize() const;
 
-	[[nodiscard]] size_t *getDimensions() const;
+    [[nodiscard]] size_t *getDimensions() const;
 
-	[[nodiscard]] size_t getDimensionCount() const;
+    [[nodiscard]] size_t getDimensionCount() const;
 
-	[[nodiscard]] size_t getChannels() const;
+    [[nodiscard]] size_t getChannels() const;
 
-	void setLocation(IEImageLocation);
+    void setLocation(IEImageLocation);
 
-	[[nodiscard]] IEImageLocation getLocation() const;
+    [[nodiscard]] IEImageLocation getLocation() const;
 };
-

--- a/src/GraphicsModule/Image/IETexture.cpp
+++ b/src/GraphicsModule/Image/IETexture.cpp
@@ -6,263 +6,358 @@
 #include "IERenderEngine.hpp"
 
 /* Include dependencies from Core. */
+#include "assimp/texture.h"
 #include "Core/LogModule/IELogger.hpp"
 
-#include "assimp/texture.h"
-
-
 IETexture::IETexture(IERenderEngine *engineLink, IETexture::CreateInfo *createInfo) {
-	create(engineLink, createInfo);
+    create(engineLink, createInfo);
 }
 
 void IETexture::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_update_texture = &IETexture::_openglUpdate_aiTexture;
-		_uploadToRAM_texture = &IETexture::_openglUploadToRAM_texture;
-		_uploadToVRAM = &IETexture::_openglUploadToVRAM;
-		_uploadToVRAM_texture = &IETexture::_openglUploadToVRAM_texture;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_update_texture = &IETexture::_vulkanUpdate_aiTexture;
-		_uploadToRAM_texture = &IETexture::_vulkanUploadToRAM_texture;
-		_uploadToVRAM = &IETexture::_vulkanUploadToVRAM;
-		_uploadToVRAM_texture = &IETexture::_vulkanUploadToVRAM_texture;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _update_texture       = &IETexture::_openglUpdate_aiTexture;
+        _uploadToRAM_texture  = &IETexture::_openglUploadToRAM_texture;
+        _uploadToVRAM         = &IETexture::_openglUploadToVRAM;
+        _uploadToVRAM_texture = &IETexture::_openglUploadToVRAM_texture;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _update_texture       = &IETexture::_vulkanUpdate_aiTexture;
+        _uploadToRAM_texture  = &IETexture::_vulkanUploadToRAM_texture;
+        _uploadToVRAM         = &IETexture::_vulkanUploadToVRAM;
+        _uploadToVRAM_texture = &IETexture::_vulkanUploadToVRAM_texture;
+    }
 }
-
 
 void IETexture::create(IERenderEngine *engineLink, IETexture::CreateInfo *createInfo) {
-	linkedRenderEngine = engineLink;
-	layout = createInfo->layout;
-	format = createInfo->format;
-	type = createInfo->type;
-	usage = createInfo->usage | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-	status = static_cast<IEImageStatus>(IE_IMAGE_STATUS_UNLOADED | IE_IMAGE_STATUS_QUEUED_RAM | IE_IMAGE_STATUS_QUEUED_VRAM);
+    linkedRenderEngine = engineLink;
+    layout             = createInfo->layout;
+    format             = createInfo->format;
+    type               = createInfo->type;
+    usage              = createInfo->usage | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    status             = static_cast<IEImageStatus>(
+      IE_IMAGE_STATUS_UNLOADED | IE_IMAGE_STATUS_QUEUED_RAM | IE_IMAGE_STATUS_QUEUED_VRAM
+    );
 
-	/**@todo Implement mip-mapping again.*/
-	// Determine image data based on settings and input data
-//        auto maxMipLevel = static_cast<uint8_t>(std::floor(std::log2(std::max(width, height))) + 1);
-//        mipLevels = mipMapping && linkedRenderEngine->settings.mipMapping ? std::min(std::max(maxMipLevel, static_cast<uint8_t>(1)), static_cast<uint8_t>(linkedRenderEngine->settings.mipMapLevel)) : 1;
+    /**@todo Implement mip-mapping again.*/
+    // Determine image data based on settings and input data
+    //        auto maxMipLevel = static_cast<uint8_t>(std::floor(std::log2(std::max(width, height))) + 1);
+    //        mipLevels = mipMapping && linkedRenderEngine->settings.mipMapping ? std::min(std::max(maxMipLevel,
+    //        static_cast<uint8_t>(1)), static_cast<uint8_t>(linkedRenderEngine->settings.mipMapLevel)) : 1;
 }
-
 
 std::function<void(IETexture &)> IETexture::_uploadToVRAM{nullptr};
 
 void IETexture::uploadToVRAM() {
-	if (width * height * channels == 0) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG, "Attempt to load image with size of zero into VRAM");
-	}
-	if (status & IE_IMAGE_STATUS_QUEUED_VRAM) {
-		_uploadToVRAM(*this);
-	}
+    if (width * height * channels == 0) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_DEBUG,
+          "Attempt to load image with size of zero into VRAM"
+        );
+    }
+    if (status & IE_IMAGE_STATUS_QUEUED_VRAM) _uploadToVRAM(*this);
 
-	// Update status
-	status = static_cast<IEImageStatus>(status & ~IE_IMAGE_STATUS_QUEUED_VRAM | IE_IMAGE_STATUS_IN_VRAM);
+    // Update status
+    status = static_cast<IEImageStatus>(status & ~IE_IMAGE_STATUS_QUEUED_VRAM | IE_IMAGE_STATUS_IN_VRAM);
 }
 
 void IETexture::_openglUploadToVRAM() {
-	glGenTextures(1, &id);
-	glBindTexture(GL_TEXTURE_2D, id);
-	
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_SRGB8_ALPHA8, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
-	glBindTexture(GL_TEXTURE_2D, 0);
-	update(data);
+    glGenTextures(1, &id);
+    glBindTexture(GL_TEXTURE_2D, id);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glTexImage2D(
+      GL_TEXTURE_2D,
+      0,
+      GL_SRGB8_ALPHA8,
+      (GLsizei) width,
+      (GLsizei) height,
+      0,
+      GL_RGBA,
+      GL_UNSIGNED_BYTE,
+      data.data()
+    );
+    glBindTexture(GL_TEXTURE_2D, 0);
+    update(data);
 }
 
 void IETexture::_vulkanUploadToVRAM() {
-	VkImageLayout desiredLayout = layout;
-	layout = VK_IMAGE_LAYOUT_UNDEFINED;
-	
-	_vulkanCreateImage();
-	_vulkanCreateImageView();
-	_vulkanCreateImageSampler();
-	
-	update(data);
-	
-	// Set transition to requested layout from undefined or dst_optimal.
-	if (layout != desiredLayout) {
-		transitionLayout(desiredLayout);
-	}
-}
+    VkImageLayout desiredLayout = layout;
+    layout                      = VK_IMAGE_LAYOUT_UNDEFINED;
 
+    _vulkanCreateImage();
+    _vulkanCreateImageView();
+    _vulkanCreateImageSampler();
+
+    update(data);
+
+    // Set transition to requested layout from undefined or dst_optimal.
+    if (layout != desiredLayout) transitionLayout(desiredLayout);
+}
 
 std::function<void(IETexture &, aiTexture *)> IETexture::_update_texture{nullptr};
 
 void IETexture::update(aiTexture *texture) {
-	_update_texture(*this, texture);
+    _update_texture(*this, texture);
 }
 
 void IETexture::_openglUpdate_aiTexture(aiTexture *texture) {
-	stbi_uc *tempData;
-	if (texture->mHeight == 0) {
-		tempData = stbi_load_from_memory((unsigned char *) texture->pcData, (int) texture->mWidth, reinterpret_cast<int *>(&width),
-										 reinterpret_cast<int *>(&height), reinterpret_cast<int *>(&channels), 4);
-	} else {
-		tempData = stbi_load(texture->mFilename.C_Str(), reinterpret_cast<int *>(&width), reinterpret_cast<int *>(&height),
-							 reinterpret_cast<int *>(&channels), 4);
-	}
-	channels = 4;  /**@todo Make number of channels imported change the number of channels in VRAM.*/
-	std::vector<char> data = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
-	if (data.empty()) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
-												 stbi_failure_reason());
-	}
-	_openglUpdate_vector(data);
+    stbi_uc *tempData;
+    if (texture->mHeight == 0) {
+        tempData = stbi_load_from_memory(
+          (unsigned char *) texture->pcData,
+          (int) texture->mWidth,
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    } else {
+        tempData = stbi_load(
+          texture->mFilename.C_Str(),
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    }
+    channels = 4; /**@todo Make number of channels imported change the number of channels in VRAM.*/
+    std::vector<char> data =
+      std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
+    if (data.empty()) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
+            stbi_failure_reason()
+        );
+    }
+    _openglUpdate_vector(data);
 }
 
 void IETexture::_vulkanUpdate_aiTexture(aiTexture *texture) {
-	stbi_uc *tempData;
-	if (texture->mHeight == 0) {
-		tempData = stbi_load_from_memory((unsigned char *) texture->pcData, (int) texture->mWidth, reinterpret_cast<int *>(&width),
-										 reinterpret_cast<int *>(&height), reinterpret_cast<int *>(&channels), 4);
-	} else {
-		tempData = stbi_load(texture->mFilename.C_Str(), reinterpret_cast<int *>(&width), reinterpret_cast<int *>(&height),
-							 reinterpret_cast<int *>(&channels), 4);
-	}
-	channels = 4;  /**@todo Make number of channels imported change the number of channels in VRAM.*/
-	std::vector<char> data = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
-	if (data.empty()) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
-												 stbi_failure_reason());
-	}
-	_vulkanUpdate_vector(data);
+    stbi_uc *tempData;
+    if (texture->mHeight == 0) {
+        tempData = stbi_load_from_memory(
+          (unsigned char *) texture->pcData,
+          (int) texture->mWidth,
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    } else {
+        tempData = stbi_load(
+          texture->mFilename.C_Str(),
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    }
+    channels = 4; /**@todo Make number of channels imported change the number of channels in VRAM.*/
+    std::vector<char> data =
+      std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
+    if (data.empty()) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
+            stbi_failure_reason()
+        );
+    }
+    _vulkanUpdate_vector(data);
 }
-
 
 std::function<void(IETexture &, aiTexture *)> IETexture::_uploadToVRAM_texture{nullptr};
 
 void IETexture::uploadToVRAM(aiTexture *texture) {
-	_uploadToVRAM_texture(*this, texture);
+    _uploadToVRAM_texture(*this, texture);
 }
 
 void IETexture::_openglUploadToVRAM_texture(aiTexture *texture) {
-	stbi_uc *tempData;
-	if (texture->mHeight == 0) {
-		tempData = stbi_load_from_memory((unsigned char *) texture->pcData, (int) texture->mWidth, reinterpret_cast<int *>(&width),
-										 reinterpret_cast<int *>(&height), reinterpret_cast<int *>(&channels), 4);
-	} else {
-		tempData = stbi_load(texture->mFilename.C_Str(), reinterpret_cast<int *>(&width), reinterpret_cast<int *>(&height),
-							 reinterpret_cast<int *>(&channels), 4);
-	}
-	channels = 4;  /**@todo Make number of channels imported change the number of channels in VRAM.*/
-	std::vector<char> data = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
-	if (data.empty()) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
-												 stbi_failure_reason());
-	}
-	
-	glGenTextures(1, &id);
-	glBindTexture(GL_TEXTURE_2D, id);
-	
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D,  GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_SRGB8_ALPHA8, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
-	glBindTexture(GL_TEXTURE_2D, 0);
-	
-	status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
+    stbi_uc *tempData;
+    if (texture->mHeight == 0) {
+        tempData = stbi_load_from_memory(
+          (unsigned char *) texture->pcData,
+          (int) texture->mWidth,
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    } else {
+        tempData = stbi_load(
+          texture->mFilename.C_Str(),
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    }
+    channels = 4; /**@todo Make number of channels imported change the number of channels in VRAM.*/
+    std::vector<char> data =
+      std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
+    if (data.empty()) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
+            stbi_failure_reason()
+        );
+    }
+
+    glGenTextures(1, &id);
+    glBindTexture(GL_TEXTURE_2D, id);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glTexImage2D(
+      GL_TEXTURE_2D,
+      0,
+      GL_SRGB8_ALPHA8,
+      (GLsizei) width,
+      (GLsizei) height,
+      0,
+      GL_RGBA,
+      GL_UNSIGNED_BYTE,
+      data.data()
+    );
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
 }
 
 void IETexture::_vulkanUploadToVRAM_texture(aiTexture *texture) {
-	stbi_uc *tempData;
-	if (texture->mHeight == 0) {
-		tempData = stbi_load_from_memory((unsigned char *) texture->pcData, (int) texture->mWidth, reinterpret_cast<int *>(&width),
-										 reinterpret_cast<int *>(&height), reinterpret_cast<int *>(&channels), 4);
-	} else {
-		tempData = stbi_load(texture->mFilename.C_Str(), reinterpret_cast<int *>(&width), reinterpret_cast<int *>(&height),
-							 reinterpret_cast<int *>(&channels), 4);
-	}
-	channels = 4;  /**@todo Make number of channels imported change the number of channels in VRAM.*/
-	std::vector<char> data = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
-	if (data.empty()) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
-												 stbi_failure_reason());
-	}
-	
-	_vulkanCreateImage();
-	_vulkanCreateImageView();
-	_vulkanCreateImageSampler();
-	
-	status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
-}
+    stbi_uc *tempData;
+    if (texture->mHeight == 0) {
+        tempData = stbi_load_from_memory(
+          (unsigned char *) texture->pcData,
+          (int) texture->mWidth,
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    } else {
+        tempData = stbi_load(
+          texture->mFilename.C_Str(),
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    }
+    channels = 4; /**@todo Make number of channels imported change the number of channels in VRAM.*/
+    std::vector<char> data =
+      std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
+    if (data.empty()) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
+            stbi_failure_reason()
+        );
+    }
 
+    _vulkanCreateImage();
+    _vulkanCreateImageView();
+    _vulkanCreateImageSampler();
+
+    status = static_cast<IEImageStatus>(status | IE_IMAGE_STATUS_IN_VRAM);
+}
 
 std::function<void(IETexture &, aiTexture *)> IETexture::_uploadToRAM_texture{nullptr};
 
 void IETexture::uploadToRAM(aiTexture *texture) {
-	_uploadToRAM_texture(*this, texture);
+    _uploadToRAM_texture(*this, texture);
 }
 
 void IETexture::_openglUploadToRAM_texture(aiTexture *texture) {
-	stbi_uc *tempData;
-	if (texture->mHeight == 0) {
-		tempData = stbi_load_from_memory((unsigned char *) texture->pcData, (int) texture->mWidth, reinterpret_cast<int *>(&width),
-										 reinterpret_cast<int *>(&height), reinterpret_cast<int *>(&channels), 4);
-	} else {
-		tempData = stbi_load(texture->mFilename.C_Str(), reinterpret_cast<int *>(&width), reinterpret_cast<int *>(&height),
-							 reinterpret_cast<int *>(&channels), 4);
-	}
-	channels = 4;  /**@todo Make number of channels imported change the number of channels in VRAM.*/
-	data = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
-	if (data.empty()) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
-												 stbi_failure_reason());
-	}
+    stbi_uc *tempData;
+    if (texture->mHeight == 0) {
+        tempData = stbi_load_from_memory(
+          (unsigned char *) texture->pcData,
+          (int) texture->mWidth,
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    } else {
+        tempData = stbi_load(
+          texture->mFilename.C_Str(),
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    }
+    channels = 4; /**@todo Make number of channels imported change the number of channels in VRAM.*/
+    data     = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
+    if (data.empty()) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
+            stbi_failure_reason()
+        );
+    }
 }
 
 void IETexture::_vulkanUploadToRAM_texture(aiTexture *texture) {
-	stbi_uc *tempData;
-	if (texture->mHeight == 0) {
-		tempData = stbi_load_from_memory((unsigned char *) texture->pcData, (int) texture->mWidth, reinterpret_cast<int *>(&width),
-										 reinterpret_cast<int *>(&height), reinterpret_cast<int *>(&channels), 4);
-	} else {
-		tempData = stbi_load(texture->mFilename.C_Str(), reinterpret_cast<int *>(&width), reinterpret_cast<int *>(&height),
-							 reinterpret_cast<int *>(&channels), 4);
-	}
-	channels = 4;  /**@todo Make number of channels imported change the number of channels in VRAM.*/
-	data = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
-	if (data.empty()) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
-												 stbi_failure_reason());
-	}
+    stbi_uc *tempData;
+    if (texture->mHeight == 0) {
+        tempData = stbi_load_from_memory(
+          (unsigned char *) texture->pcData,
+          (int) texture->mWidth,
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    } else {
+        tempData = stbi_load(
+          texture->mFilename.C_Str(),
+          reinterpret_cast<int *>(&width),
+          reinterpret_cast<int *>(&height),
+          reinterpret_cast<int *>(&channels),
+          4
+        );
+    }
+    channels = 4; /**@todo Make number of channels imported change the number of channels in VRAM.*/
+    data     = std::vector<char>{(char *) tempData, (char *) ((uint64_t) tempData + width * height * channels)};
+    if (data.empty()) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          std::string{"Failed to load image data from file: '"} + texture->mFilename.C_Str() + "' due to " +
+            stbi_failure_reason()
+        );
+    }
 }
 
-
 void IETexture::_vulkanCreateImageSampler() {
-	// Set up image sampler create info.
-	VkSamplerCreateInfo samplerCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
-			.magFilter=VK_FILTER_NEAREST,
-			.minFilter=VK_FILTER_NEAREST,
-			.mipmapMode=VK_SAMPLER_MIPMAP_MODE_LINEAR,
-			.addressModeU=VK_SAMPLER_ADDRESS_MODE_REPEAT,
-			.addressModeV=VK_SAMPLER_ADDRESS_MODE_REPEAT,
-			.addressModeW=VK_SAMPLER_ADDRESS_MODE_REPEAT,
-			.mipLodBias=linkedRenderEngine->settings->mipMapLevel,
-//                .anisotropyEnable=linkedRenderEngine->settings.anisotropicFilterLevel > 0,
-//                .maxAnisotropy=anisotropyLevel,
-			.compareEnable=VK_FALSE,
-			.compareOp=VK_COMPARE_OP_ALWAYS,
-			.minLod=0.0F,
-//                .maxLod=static_cast<float>(mipLevels),
-			.borderColor=VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE,
-			.unnormalizedCoordinates=VK_FALSE,
-	};
-	
-	// Create image sampler
-	if (vkCreateSampler(linkedRenderEngine->device.device, &samplerCreateInfo, nullptr, &sampler) != VK_SUCCESS) {
-		throw std::runtime_error("failed to create texture sampler!");
-	}
+    // Set up image sampler create info.
+    VkSamplerCreateInfo samplerCreateInfo{
+      .sType                   = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+      .magFilter               = VK_FILTER_NEAREST,
+      .minFilter               = VK_FILTER_NEAREST,
+      .mipmapMode              = VK_SAMPLER_MIPMAP_MODE_LINEAR,
+      .addressModeU            = VK_SAMPLER_ADDRESS_MODE_REPEAT,
+      .addressModeV            = VK_SAMPLER_ADDRESS_MODE_REPEAT,
+      .addressModeW            = VK_SAMPLER_ADDRESS_MODE_REPEAT,
+      .mipLodBias              = linkedRenderEngine->settings->mipMapLevel,
+      //                .anisotropyEnable=linkedRenderEngine->settings.anisotropicFilterLevel > 0,
+      //                .maxAnisotropy=anisotropyLevel,
+      .compareEnable           = VK_FALSE,
+      .compareOp               = VK_COMPARE_OP_ALWAYS,
+      .minLod                  = 0.0F,
+      //                .maxLod=static_cast<float>(mipLevels),
+      .borderColor             = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE,
+      .unnormalizedCoordinates = VK_FALSE,
+    };
+
+    // Create image sampler
+    if (vkCreateSampler(linkedRenderEngine->device.device, &samplerCreateInfo, nullptr, &sampler) != VK_SUCCESS)
+        throw std::runtime_error("failed to create texture sampler!");
 }

--- a/src/GraphicsModule/Image/IETexture.hpp
+++ b/src/GraphicsModule/Image/IETexture.hpp
@@ -9,9 +9,8 @@ class IEBuffer;
 
 // External dependencies
 #include <assimp/material.h>
-#include <vulkan/vulkan.h>
-
 #include <stb_image.h>
+#include <vulkan/vulkan.h>
 
 // System dependencies
 #include <cstdint>
@@ -21,77 +20,77 @@ struct aiTexture;
 
 class IETexture : public IEImage {
 public:
-	struct CreateInfo {
-		VkFormat format{VK_FORMAT_R8G8B8A8_SRGB};
-		VkImageLayout layout{VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-		VkImageType type{VK_IMAGE_TYPE_2D};
-		VkImageUsageFlags usage{VK_IMAGE_USAGE_SAMPLED_BIT};
-		VkImageCreateFlags flags{};
-		VmaMemoryUsage allocationUsage{};
-	};
-	
-	std::string filename{};
-	
-	IETexture() = default;
+    struct CreateInfo {
+        VkFormat           format{VK_FORMAT_R8G8B8A8_SRGB};
+        VkImageLayout      layout{VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+        VkImageType        type{VK_IMAGE_TYPE_2D};
+        VkImageUsageFlags  usage{VK_IMAGE_USAGE_SAMPLED_BIT};
+        VkImageCreateFlags flags{};
+        VmaMemoryUsage     allocationUsage{};
+    };
 
-	IETexture(IERenderEngine *, IETexture::CreateInfo *);
+    std::string filename{};
 
-	static void setAPI(const IEAPI &);
+    IETexture() = default;
+
+    IETexture(IERenderEngine *, IETexture::CreateInfo *);
+
+    static void setAPI(const IEAPI &);
 
 
-	void create(IERenderEngine *, IETexture::CreateInfo *);
+    void create(IERenderEngine *, IETexture::CreateInfo *);
 
 private:
-	static std::function<void(IETexture &)> _uploadToVRAM;
-	
-	static std::function<void(IETexture &, aiTexture *)> _uploadToRAM_texture;
-	
-	static std::function<void(IETexture &, aiTexture *)> _uploadToVRAM_texture;
-	
-	static std::function<void(IETexture &, aiTexture *)> _update_texture;
-	
+    static std::function<void(IETexture &)> _uploadToVRAM;
+
+    static std::function<void(IETexture &, aiTexture *)> _uploadToRAM_texture;
+
+    static std::function<void(IETexture &, aiTexture *)> _uploadToVRAM_texture;
+
+    static std::function<void(IETexture &, aiTexture *)> _update_texture;
+
 protected:
-	void _openglUploadToVRAM() override;
+    void _openglUploadToVRAM() override;
 
-	void _vulkanUploadToVRAM() override;
+    void _vulkanUploadToVRAM() override;
 
 
-	virtual void _openglUpdate_aiTexture(aiTexture *);
+    virtual void _openglUpdate_aiTexture(aiTexture *);
 
-	virtual void _vulkanUpdate_aiTexture(aiTexture *);
-	
-	
-	virtual void _openglUploadToRAM_texture(aiTexture *);
-	
-	virtual void _vulkanUploadToRAM_texture(aiTexture *);
-	
-	
-	virtual void _openglUploadToVRAM_texture(aiTexture *);
-	
-	virtual void _vulkanUploadToVRAM_texture(aiTexture *);
-	
-	
-	void _vulkanCreateImageSampler();
-	
+    virtual void _vulkanUpdate_aiTexture(aiTexture *);
+
+
+    virtual void _openglUploadToRAM_texture(aiTexture *);
+
+    virtual void _vulkanUploadToRAM_texture(aiTexture *);
+
+
+    virtual void _openglUploadToVRAM_texture(aiTexture *);
+
+    virtual void _vulkanUploadToVRAM_texture(aiTexture *);
+
+
+    void _vulkanCreateImageSampler();
+
 public:
-	using IEImage::uploadToRAM;
-	
-	void uploadToRAM(aiTexture *);
-	
-	using IEImage::uploadToVRAM;
-	
-	void uploadToVRAM(aiTexture *);
-	
-	
-	void uploadToVRAM() override;
-	
-	using IEImage::update;
-	
-	
-	void update(aiTexture *);
-	
-	
-	using IEImage::unloadFromVRAM;
-	
-	using IEImage::destroy;
+    using IEImage::uploadToRAM;
+
+    void uploadToRAM(aiTexture *);
+
+    using IEImage::uploadToVRAM;
+
+    void uploadToVRAM(aiTexture *);
+
+
+    void uploadToVRAM() override;
+
+    using IEImage::update;
+
+
+    void update(aiTexture *);
+
+
+    using IEImage::unloadFromVRAM;
+
+    using IEImage::destroy;
 };

--- a/src/GraphicsModule/Image/IETextureNEW.hpp
+++ b/src/GraphicsModule/Image/IETextureNEW.hpp
@@ -4,5 +4,5 @@
 
 template<uint32_t width = 0, uint32_t height = 0, uint8_t channels = 0>
 class IETextureNEW : public IEImageNEW<width, height, channels> {
-/** Implementations of the texturing minutia. */
+    /** Implementations of the texturing minutia. */
 };

--- a/src/GraphicsModule/RenderPass/IEFramebuffer.cpp
+++ b/src/GraphicsModule/RenderPass/IEFramebuffer.cpp
@@ -5,80 +5,81 @@
 #include "GraphicsModule/IERenderEngine.hpp"
 #include "GraphicsModule/RenderPass/IERenderPass.hpp"
 
-
 void IEFramebuffer::create(IERenderEngine *engineLink, IEFramebuffer::CreateInfo *createInfo) {
-	linkedRenderEngine = engineLink;
-	
-	std::array<VkImageLayout, 7> disallowedLayouts{VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL};
-	
-	framebuffers.resize(linkedRenderEngine->swapchainImageViews.size());
-	
-	for (const Attachment& attachment : createInfo->attachments) {
-		if (std::find(disallowedLayouts.begin(), disallowedLayouts.end(), attachment.forceLayout) == disallowedLayouts.end()) {
-			attachments.push_back(attachment.image);
-		} else {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Attempt to attach to framebuffer with invalid layout!" + std::to_string(attachment.forceLayout));
-		}
-	}
+    linkedRenderEngine = engineLink;
 
-	// Copy createInfo data into this image
-	renderPass = createInfo->renderPass;
-	defaultColor = createInfo->defaultColor;
+    std::array<VkImageLayout, 7> disallowedLayouts{
+      VK_IMAGE_LAYOUT_UNDEFINED,
+      VK_IMAGE_LAYOUT_PREINITIALIZED,
+      VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+      VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+      VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
+      VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
+      VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL};
 
-	// Verify that width and height are suitable
-	width = static_cast<uint16_t>(linkedRenderEngine->swapchain.extent.width);
-	height = static_cast<uint16_t>(linkedRenderEngine->swapchain.extent.height);
+    framebuffers.resize(linkedRenderEngine->swapchainImageViews.size());
 
-	if (linkedRenderEngine->swapchainImageViews[0] == VK_NULL_HANDLE) {
-		throw std::runtime_error("IEFramebuffer::CreateInfo::swapchainImageViews[0] cannot be VK_NULL_HANDLE!");
-	}
-	if (!renderPass.lock()) {
-		throw std::runtime_error("IEFramebuffer::CreateInfo::renderPass must exist!");
-	}
-	clearValues[0].color = VkClearColorValue{defaultColor[0], defaultColor[1], defaultColor[2], defaultColor[3]};
-	clearValues[1].depthStencil = {1.0F, 0};
-	clearValues[2].color = clearValues[0].color;
+    for (const Attachment &attachment : createInfo->attachments) {
+        if (std::find(disallowedLayouts.begin(), disallowedLayouts.end(), attachment.forceLayout) ==
+            disallowedLayouts.end()) {
+            attachments.push_back(attachment.image);
+        } else {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+              "Attempt to attach to framebuffer with invalid layout!" + std::to_string(attachment.forceLayout)
+            );
+        }
+    }
 
-//	uint8_t msaaSamplesAllowed = getHighestMSAASampleCount(linkedRenderEngine->settings->msaaSamples);
+    // Copy createInfo data into this image
+    renderPass   = createInfo->renderPass;
+    defaultColor = createInfo->defaultColor;
 
-	for (size_t i = 0; i < linkedRenderEngine->swapchain.image_count; ++i) {
-		std::vector<VkImageView> framebufferAttachments{};
-		framebufferAttachments.reserve(attachments.size() + 2);
-		framebufferAttachments.push_back(linkedRenderEngine->swapchainImageViews[i]);
-		framebufferAttachments.push_back(linkedRenderEngine->depthImage->view);
-		for (const std::shared_ptr<IEImage>& image : attachments) {
-			framebufferAttachments.push_back(image->view);
-		}
-		VkFramebufferCreateInfo framebufferCreateInfo{
-				.sType=VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-				.renderPass = renderPass.lock()->renderPass,
-				.attachmentCount=static_cast<uint32_t>(framebufferAttachments.size()),
-				.pAttachments=framebufferAttachments.data(),
-				.width=linkedRenderEngine->swapchain.extent.width,
-				.height=linkedRenderEngine->swapchain.extent.height,
-				.layers=1
-		};
-		if (vkCreateFramebuffer(linkedRenderEngine->device.device, &framebufferCreateInfo, nullptr, &framebuffers[i]) != VK_SUCCESS) {
-			throw std::runtime_error("failed to create framebuffers!");
-		}
-	}
+    // Verify that width and height are suitable
+    width  = static_cast<uint16_t>(linkedRenderEngine->swapchain.extent.width);
+    height = static_cast<uint16_t>(linkedRenderEngine->swapchain.extent.height);
+
+    if (linkedRenderEngine->swapchainImageViews[0] == VK_NULL_HANDLE)
+        throw std::runtime_error("IEFramebuffer::CreateInfo::swapchainImageViews[0] cannot be VK_NULL_HANDLE!");
+    if (!renderPass.lock()) throw std::runtime_error("IEFramebuffer::CreateInfo::renderPass must exist!");
+    clearValues[0].color = VkClearColorValue{defaultColor[0], defaultColor[1], defaultColor[2], defaultColor[3]};
+    clearValues[1].depthStencil = {1.0F, 0};
+    clearValues[2].color        = clearValues[0].color;
+
+    //	uint8_t msaaSamplesAllowed = getHighestMSAASampleCount(linkedRenderEngine->settings->msaaSamples);
+
+    for (size_t i = 0; i < linkedRenderEngine->swapchain.image_count; ++i) {
+        std::vector<VkImageView> framebufferAttachments{};
+        framebufferAttachments.reserve(attachments.size() + 2);
+        framebufferAttachments.push_back(linkedRenderEngine->swapchainImageViews[i]);
+        framebufferAttachments.push_back(linkedRenderEngine->depthImage->view);
+        for (const std::shared_ptr<IEImage> &image : attachments) framebufferAttachments.push_back(image->view);
+        VkFramebufferCreateInfo framebufferCreateInfo{
+          .sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+          .renderPass      = renderPass.lock()->renderPass,
+          .attachmentCount = static_cast<uint32_t>(framebufferAttachments.size()),
+          .pAttachments    = framebufferAttachments.data(),
+          .width           = linkedRenderEngine->swapchain.extent.width,
+          .height          = linkedRenderEngine->swapchain.extent.height,
+          .layers          = 1};
+        if (vkCreateFramebuffer(linkedRenderEngine->device.device, &framebufferCreateInfo, nullptr, &framebuffers[i]) != VK_SUCCESS) {
+            throw std::runtime_error("failed to create framebuffers!");
+        }
+    }
 }
 
 IEFramebuffer::IEFramebuffer() = default;
 
 IEFramebuffer::~IEFramebuffer() {
-	for (VkFramebuffer framebuffer : framebuffers) {
-		vkDestroyFramebuffer(linkedRenderEngine->device.device, framebuffer, nullptr);
-	}
-	for (std::shared_ptr<IEImage> &attachment : attachments) {
-		attachment->destroy();
-	}
+    for (VkFramebuffer framebuffer : framebuffers)
+        vkDestroyFramebuffer(linkedRenderEngine->device.device, framebuffer, nullptr);
+    for (std::shared_ptr<IEImage> &attachment : attachments) attachment->destroy();
 }
 
 VkFramebuffer IEFramebuffer::operator[](uint8_t index) {
-	return framebuffers[index];
+    return framebuffers[index];
 }
 
 VkFramebuffer IEFramebuffer::getFramebuffer(uint8_t index) {
-	return framebuffers[index];
+    return framebuffers[index];
 }

--- a/src/GraphicsModule/RenderPass/IEFramebuffer.hpp
+++ b/src/GraphicsModule/RenderPass/IEFramebuffer.hpp
@@ -14,38 +14,37 @@ class IERenderEngine;
 #include <string>
 #include <vector>
 
-
 class IEFramebuffer : public IEDependency {
 public:
-	class Attachment {
-	public:
-		std::shared_ptr<IEImage> image{};
-		VkImageLayout forceLayout{};
-		uint8_t location{};
-	};
-	
-	struct CreateInfo {
-		std::weak_ptr<IERenderPass> renderPass{};
-		std::vector<float> defaultColor{0.0F, 0.0F, 0.0F, 1.0F};
-		std::vector<Attachment> attachments{};
-	};
-	
-	std::vector<VkFramebuffer> framebuffers{};
-	std::vector<VkClearValue> clearValues{3};
-	std::vector<float> defaultColor{1.0F, 0.0F, 0.0F, 1.0F};
-	std::weak_ptr<IERenderPass> renderPass{};
-	std::vector<std::shared_ptr<IEImage>> attachments{};
-	IERenderEngine *linkedRenderEngine{};
-	uint16_t width{};
-	uint16_t height{};
-	
-	VkFramebuffer getFramebuffer(uint8_t index);
+    class Attachment {
+    public:
+        std::shared_ptr<IEImage> image{};
+        VkImageLayout            forceLayout{};
+        uint8_t                  location{};
+    };
 
-	IEFramebuffer();
+    struct CreateInfo {
+        std::weak_ptr<IERenderPass> renderPass{};
+        std::vector<float>          defaultColor{0.0F, 0.0F, 0.0F, 1.0F};
+        std::vector<Attachment>     attachments{};
+    };
 
-	~IEFramebuffer() override;
-	
-	void create(IERenderEngine *engineLink, CreateInfo *createInfo);
-	
-	VkFramebuffer operator[](uint8_t index);
+    std::vector<VkFramebuffer>            framebuffers{};
+    std::vector<VkClearValue>             clearValues{3};
+    std::vector<float>                    defaultColor{1.0F, 0.0F, 0.0F, 1.0F};
+    std::weak_ptr<IERenderPass>           renderPass{};
+    std::vector<std::shared_ptr<IEImage>> attachments{};
+    IERenderEngine                       *linkedRenderEngine{};
+    uint16_t                              width{};
+    uint16_t                              height{};
+
+    VkFramebuffer getFramebuffer(uint8_t index);
+
+    IEFramebuffer();
+
+    ~IEFramebuffer() override;
+
+    void create(IERenderEngine *engineLink, CreateInfo *createInfo);
+
+    VkFramebuffer operator[](uint8_t index);
 };

--- a/src/GraphicsModule/RenderPass/IERenderPass.cpp
+++ b/src/GraphicsModule/RenderPass/IERenderPass.cpp
@@ -4,136 +4,126 @@
 #include <memory>
 
 /* Include dependencies within this module. */
-#include "IERenderEngine.hpp"
 #include "IEFramebuffer.hpp"
+#include "IERenderEngine.hpp"
 
 /* Include dependencies from Core. */
 #include "Core/LogModule/IELogger.hpp"
 
-
 void IERenderPass::create(IERenderEngine *engineLink, IERenderPass::CreateInfo *createInfo) {
-	createdWith = *createInfo;
-	linkedRenderEngine = engineLink;
+    createdWith        = *createInfo;
+    linkedRenderEngine = engineLink;
 
-	linkedRenderEngine->settings->msaaSamples = VK_SAMPLE_COUNT_1_BIT;
-	
-	// Generate attachment descriptions
-	uint8_t thisAttachmentMsaaSampleCount = std::max(static_cast<uint8_t>(1),
-													 std::min(linkedRenderEngine->settings->msaaSamples, createdWith.msaaSamples));
+    linkedRenderEngine->settings->msaaSamples = VK_SAMPLE_COUNT_1_BIT;
 
-	VkAttachmentDescription colorAttachmentDescription{
-			.format=linkedRenderEngine->swapchain.image_format,
-			.samples=static_cast<VkSampleCountFlagBits>(thisAttachmentMsaaSampleCount),
-			.loadOp=VK_ATTACHMENT_LOAD_OP_CLEAR,
-			.storeOp=VK_ATTACHMENT_STORE_OP_STORE,
-			.stencilLoadOp=VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-			.stencilStoreOp=VK_ATTACHMENT_STORE_OP_DONT_CARE,
-			.initialLayout=VK_IMAGE_LAYOUT_UNDEFINED,
-			.finalLayout=thisAttachmentMsaaSampleCount == VK_SAMPLE_COUNT_1_BIT ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-																				: VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-	};
-	VkAttachmentDescription depthAttachmentDescription{
-			.format=VK_FORMAT_D32_SFLOAT_S8_UINT,
-			.samples=static_cast<VkSampleCountFlagBits>(thisAttachmentMsaaSampleCount),
-			.loadOp=VK_ATTACHMENT_LOAD_OP_CLEAR,
-			.storeOp=VK_ATTACHMENT_STORE_OP_STORE,
-			.stencilLoadOp=VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-			.stencilStoreOp=VK_ATTACHMENT_STORE_OP_DONT_CARE,
-			.initialLayout=VK_IMAGE_LAYOUT_UNDEFINED,
-			.finalLayout=VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-	};
-	VkAttachmentDescription colorResolveAttachmentDescription{
-			.format=linkedRenderEngine->swapchain.image_format,
-			.samples=VK_SAMPLE_COUNT_1_BIT,
-			.loadOp=VK_ATTACHMENT_LOAD_OP_CLEAR,
-			.storeOp=VK_ATTACHMENT_STORE_OP_STORE,
-			.stencilLoadOp=VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-			.stencilStoreOp=VK_ATTACHMENT_STORE_OP_DONT_CARE,
-			.initialLayout=VK_IMAGE_LAYOUT_UNDEFINED,
-			.finalLayout=VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-	};
-	VkAttachmentReference colorAttachmentReference{
-			.attachment=0,
-			.layout=VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-	};
-	VkAttachmentReference depthAttachmentReference{
-			.attachment=1,
-			.layout=VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-	};
-	VkAttachmentReference colorResolveAttachmentReference{
-			.attachment=2,
-			.layout=VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-	};
-	VkSubpassDescription subpassDescription{
-			.pipelineBindPoint=VK_PIPELINE_BIND_POINT_GRAPHICS,
-			.colorAttachmentCount=1,
-			.pColorAttachments=&colorAttachmentReference,
-			.pResolveAttachments=thisAttachmentMsaaSampleCount == VK_SAMPLE_COUNT_1_BIT ? nullptr : &colorResolveAttachmentReference,
-			.pDepthStencilAttachment=&depthAttachmentReference
-	};
-	VkSubpassDependency subpassDependency{
-			.srcSubpass=VK_SUBPASS_EXTERNAL,
-			.dstSubpass=0,
-			.srcStageMask=VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
-			.dstStageMask=VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
-			.srcAccessMask=0,
-			.dstAccessMask=VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
-	};
-	std::vector<VkAttachmentDescription> attachmentDescriptions{
-			colorAttachmentDescription,
-			depthAttachmentDescription
-	};
-	if (thisAttachmentMsaaSampleCount > VK_SAMPLE_COUNT_1_BIT) {
-		attachmentDescriptions.push_back(colorResolveAttachmentDescription);
-	}
-	VkRenderPassCreateInfo renderPassCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-			.attachmentCount=static_cast<uint32_t>(attachmentDescriptions.size()),
-			.pAttachments=attachmentDescriptions.data(),
-			.subpassCount=1,
-			.pSubpasses=&subpassDescription,
-			.dependencyCount=1,
-			.pDependencies=&subpassDependency
-	};
-	if (vkCreateRenderPass(linkedRenderEngine->device.device, &renderPassCreateInfo, nullptr, &renderPass) != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create render pass!");
-	}
-	deletionQueue.emplace_back([&] {
-		vkDestroyRenderPass(linkedRenderEngine->device.device, renderPass, nullptr);
-	});
+    // Generate attachment descriptions
+    uint8_t thisAttachmentMsaaSampleCount = std::max(
+      static_cast<uint8_t>(1),
+      std::min(linkedRenderEngine->settings->msaaSamples, createdWith.msaaSamples)
+    );
 
-	// Create framebuffers
-	IEFramebuffer::CreateInfo framebufferCreateInfo{
-			.renderPass=weak_from_this(),
-			.attachments={}
-	};
-	framebuffer = std::make_shared<IEFramebuffer>();
-	framebuffer->create(linkedRenderEngine, &framebufferCreateInfo);
+    VkAttachmentDescription colorAttachmentDescription{
+      .format         = linkedRenderEngine->swapchain.image_format,
+      .samples        = static_cast<VkSampleCountFlagBits>(thisAttachmentMsaaSampleCount),
+      .loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp        = VK_ATTACHMENT_STORE_OP_STORE,
+      .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+      .initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED,
+      .finalLayout    = thisAttachmentMsaaSampleCount == VK_SAMPLE_COUNT_1_BIT ?
+           VK_IMAGE_LAYOUT_PRESENT_SRC_KHR :
+           VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    VkAttachmentDescription depthAttachmentDescription{
+      .format         = VK_FORMAT_D32_SFLOAT_S8_UINT,
+      .samples        = static_cast<VkSampleCountFlagBits>(thisAttachmentMsaaSampleCount),
+      .loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp        = VK_ATTACHMENT_STORE_OP_STORE,
+      .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+      .initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED,
+      .finalLayout    = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
+    VkAttachmentDescription colorResolveAttachmentDescription{
+      .format         = linkedRenderEngine->swapchain.image_format,
+      .samples        = VK_SAMPLE_COUNT_1_BIT,
+      .loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR,
+      .storeOp        = VK_ATTACHMENT_STORE_OP_STORE,
+      .stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+      .initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED,
+      .finalLayout    = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR};
+    VkAttachmentReference colorAttachmentReference{
+      .attachment = 0,
+      .layout     = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    VkAttachmentReference depthAttachmentReference{
+      .attachment = 1,
+      .layout     = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+    };
+    VkAttachmentReference colorResolveAttachmentReference{
+      .attachment = 2,
+      .layout     = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    VkSubpassDescription subpassDescription{
+      .pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS,
+      .colorAttachmentCount = 1,
+      .pColorAttachments    = &colorAttachmentReference,
+      .pResolveAttachments =
+        thisAttachmentMsaaSampleCount == VK_SAMPLE_COUNT_1_BIT ? nullptr : &colorResolveAttachmentReference,
+      .pDepthStencilAttachment = &depthAttachmentReference};
+    VkSubpassDependency subpassDependency{
+      .srcSubpass    = VK_SUBPASS_EXTERNAL,
+      .dstSubpass    = 0,
+      .srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+      .dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+      .srcAccessMask = 0,
+      .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT};
+    std::vector<VkAttachmentDescription> attachmentDescriptions{
+      colorAttachmentDescription,
+      depthAttachmentDescription};
+    if (thisAttachmentMsaaSampleCount > VK_SAMPLE_COUNT_1_BIT)
+        attachmentDescriptions.push_back(colorResolveAttachmentDescription);
+    VkRenderPassCreateInfo renderPassCreateInfo{
+      .sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+      .attachmentCount = static_cast<uint32_t>(attachmentDescriptions.size()),
+      .pAttachments    = attachmentDescriptions.data(),
+      .subpassCount    = 1,
+      .pSubpasses      = &subpassDescription,
+      .dependencyCount = 1,
+      .pDependencies   = &subpassDependency};
+    if (vkCreateRenderPass(linkedRenderEngine->device.device, &renderPassCreateInfo, nullptr, &renderPass) != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to create render pass!"
+        );
+    }
+    deletionQueue.emplace_back([&] { vkDestroyRenderPass(linkedRenderEngine->device.device, renderPass, nullptr); }
+    );
+
+    // Create framebuffers
+    IEFramebuffer::CreateInfo framebufferCreateInfo{.renderPass = weak_from_this(), .attachments = {}};
+    framebuffer = std::make_shared<IEFramebuffer>();
+    framebuffer->create(linkedRenderEngine, &framebufferCreateInfo);
 }
 
 IERenderPassBeginInfo IERenderPass::beginRenderPass(uint8_t index) {
-	IERenderPassBeginInfo renderPassBeginInfo{
-			.renderPass=shared_from_this(),
-			.framebuffer=framebuffer,
-			.framebufferIndex=index,
-			.renderArea{
-					.offset={0, 0},
-					.extent=linkedRenderEngine->swapchain.extent,
-			},
-			.clearValueCount=static_cast<uint32_t>(framebuffer->clearValues.size()),
-			.pClearValues=framebuffer->clearValues.data(),
-	};
-	return renderPassBeginInfo;
+    IERenderPassBeginInfo renderPassBeginInfo{
+      .renderPass       = shared_from_this(),
+      .framebuffer      = framebuffer,
+      .framebufferIndex = index,
+      .renderArea{
+                  .offset = {0, 0},
+                  .extent = linkedRenderEngine->swapchain.extent,
+                  },
+      .clearValueCount = static_cast<uint32_t>(framebuffer->clearValues.size()),
+      .pClearValues    = framebuffer->clearValues.data(),
+    };
+    return renderPassBeginInfo;
 }
 
 void IERenderPass::destroy() {
-	invalidateDependents();
-	for (std::function<void()> &function: deletionQueue) {
-		function();
-	}
-	deletionQueue.clear();
+    invalidateDependents();
+    for (std::function<void()> &function : deletionQueue) function();
+    deletionQueue.clear();
 }
 
 IERenderPass::~IERenderPass() {
-	destroy();
+    destroy();
 }

--- a/src/GraphicsModule/RenderPass/IERenderPass.hpp
+++ b/src/GraphicsModule/RenderPass/IERenderPass.hpp
@@ -7,38 +7,38 @@ class IERenderPassBeginInfo;
 
 /* Include classes used as attributes or function arguments. */
 // Internal dependencies
-#include "IEFramebuffer.hpp"
 #include "CommandBuffer/IECommandBuffer.hpp"
+#include "IEFramebuffer.hpp"
 
 // External dependencies
 #include <vulkan/vulkan.h>
 
 // System dependencies
 #include <cstdint>
-#include <vector>
 #include <functional>
+#include <vector>
 
 
 class IERenderEngine;
 
 class IERenderPass : public IEDependency, public std::enable_shared_from_this<IERenderPass> {
 public:
-	struct CreateInfo {
-		uint8_t msaaSamples{1};
-	} createdWith;
+    struct CreateInfo {
+        uint8_t msaaSamples{1};
+    } createdWith;
 
-	VkRenderPass renderPass{};
-	std::shared_ptr<IEFramebuffer> framebuffer{};
+    VkRenderPass                   renderPass{};
+    std::shared_ptr<IEFramebuffer> framebuffer{};
 
-	void create(IERenderEngine *engineLink, CreateInfo *createInfo);
+    void create(IERenderEngine *engineLink, CreateInfo *createInfo);
 
-	IERenderPassBeginInfo beginRenderPass(uint8_t index);
+    IERenderPassBeginInfo beginRenderPass(uint8_t index);
 
-	void destroy();
+    void destroy();
 
-	~IERenderPass() override;
+    ~IERenderPass() override;
 
 private:
-	std::vector<std::function<void()>> deletionQueue{};
-	IERenderEngine *linkedRenderEngine{};
+    std::vector<std::function<void()>> deletionQueue{};
+    IERenderEngine                    *linkedRenderEngine{};
 };

--- a/src/GraphicsModule/RenderPass/SubPass.hpp
+++ b/src/GraphicsModule/RenderPass/SubPass.hpp
@@ -1,5 +1,3 @@
 #pragma once
 
-class SubPass {
-
-};
+class SubPass {};

--- a/src/GraphicsModule/Renderable/IEMaterial.cpp
+++ b/src/GraphicsModule/Renderable/IEMaterial.cpp
@@ -1,189 +1,174 @@
 #include "IEMaterial.hpp"
 
+#include "IEMesh.hpp"
+#include "IERenderEngine.hpp"
+
 #include <memory>
 
-#include "IERenderEngine.hpp"
-#include "IEMesh.hpp"
-
 IEMaterial::IEMaterial(IERenderEngine *engineLink) {
-	create(engineLink);
+    create(engineLink);
 }
 
 void IEMaterial::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_create = &IEMaterial::_openglCreate;
-		_loadFromDiskToRAM = &IEMaterial::_openglLoadFromDiskToRAM;
-		_loadFromRAMToVRAM = &IEMaterial::_openglLoadFromRAMToVRAM;
-		_unloadFromVRAM = &IEMaterial::_openglUnloadFromVRAM;
-		_unloadFromRAM = &IEMaterial::_openglUnloadFromRAM;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_create = &IEMaterial::_vulkanCreate;
-		_loadFromDiskToRAM = &IEMaterial::_vulkanLoadFromDiskToRAM;
-		_loadFromRAMToVRAM = &IEMaterial::_vulkanLoadFromRAMToVRAM;
-		_unloadFromVRAM = &IEMaterial::_vulkanUnloadFromVRAM;
-		_unloadFromRAM = &IEMaterial::_vulkanUnloadFromRAM;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _create            = &IEMaterial::_openglCreate;
+        _loadFromDiskToRAM = &IEMaterial::_openglLoadFromDiskToRAM;
+        _loadFromRAMToVRAM = &IEMaterial::_openglLoadFromRAMToVRAM;
+        _unloadFromVRAM    = &IEMaterial::_openglUnloadFromVRAM;
+        _unloadFromRAM     = &IEMaterial::_openglUnloadFromRAM;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _create            = &IEMaterial::_vulkanCreate;
+        _loadFromDiskToRAM = &IEMaterial::_vulkanLoadFromDiskToRAM;
+        _loadFromRAMToVRAM = &IEMaterial::_vulkanLoadFromRAMToVRAM;
+        _unloadFromVRAM    = &IEMaterial::_vulkanUnloadFromVRAM;
+        _unloadFromRAM     = &IEMaterial::_vulkanUnloadFromRAM;
+    }
 }
-
 
 std::function<void(IEMaterial &)> IEMaterial::_create{nullptr};
 
 void IEMaterial::create(IERenderEngine *engineLink) {
-	linkedRenderEngine = engineLink;
-	_create(*this);
+    linkedRenderEngine = engineLink;
+    _create(*this);
 }
 
 void IEMaterial::_openglCreate() {
-
 }
 
 void IEMaterial::_vulkanCreate() {
-
 }
 
-
-std::function<void(IEMaterial &, const std::string &, const aiScene *, uint32_t)> IEMaterial::_loadFromDiskToRAM{nullptr};
+std::function<void(IEMaterial &, const std::string &, const aiScene *, uint32_t)> IEMaterial::_loadFromDiskToRAM{
+  nullptr};
 
 void IEMaterial::loadFromDiskToRAM(const std::string &directory, const aiScene *scene, uint32_t index) {
-	_loadFromDiskToRAM(*this, directory, scene, index);
+    _loadFromDiskToRAM(*this, directory, scene, index);
 }
 
 void IEMaterial::_openglLoadFromDiskToRAM(const std::string &directory, const aiScene *scene, uint32_t index) {
-	aiMaterial *material = scene->mMaterials[index];
+    aiMaterial *material = scene->mMaterials[index];
 
-	// find all textures in scene including embedded textures
-	textureCount = 0;
-	uint32_t thisCount;
-	/**@todo Build a system that tracks duplicate textures and only keeps one copy in memory.*/
-	for (size_t i = 0; i < supportedTextureTypes.size(); ++i) {
-		thisCount = material->GetTextureCount(supportedTextureTypes[i].second);
-		if (thisCount == 0) {
-			supportedTextureTypes.erase(supportedTextureTypes.begin() + i--);  // Remove any unused texture types
-		}
-		textureCount += thisCount;
-	}
-	linkedRenderEngine->textures.reserve(linkedRenderEngine->textures.size() + textureCount);
+    // find all textures in scene including embedded textures
+    textureCount = 0;
+    uint32_t thisCount;
+    /**@todo Build a system that tracks duplicate textures and only keeps one copy in memory.*/
+    for (size_t i = 0; i < supportedTextureTypes.size(); ++i) {
+        thisCount = material->GetTextureCount(supportedTextureTypes[i].second);
+        if (thisCount == 0)
+            supportedTextureTypes.erase(supportedTextureTypes.begin() + i--);  // Remove any unused texture types
+        textureCount += thisCount;
+    }
+    linkedRenderEngine->textures.reserve(linkedRenderEngine->textures.size() + textureCount);
 
-	aiString texturePath{};
-	std::string data{};
-	aiTexture *texture;
-	uint32_t textureIndex{0};
-	IETexture::CreateInfo imageCreateInfo{};
-	
-	// load all textures despite embedded state
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		while (texturePath.length == 0 && textureIndex < textureCount) {
-			material->GetTexture(textureType.second, textureIndex++, &texturePath);
-		}
-		texture = const_cast<aiTexture *>(scene->GetEmbeddedTexture(texturePath.C_Str()));
-		if (texture == nullptr || texture->mHeight != 0) {  // is the texture not an embedded texture?
-			texture = new aiTexture;
-			texture->mFilename = directory.substr(0, directory.find_last_of('/')) + "/textures/" + texturePath.C_Str();
-			texture->mHeight = 1;  // flag texture as not embedded
-		}
-		*textureType.first = linkedRenderEngine->textures.size();
+    aiString              texturePath{};
+    std::string           data{};
+    aiTexture            *texture;
+    uint32_t              textureIndex{0};
+    IETexture::CreateInfo imageCreateInfo{};
 
-		linkedRenderEngine->textures.push_back(std::make_shared<IETexture>(linkedRenderEngine, &imageCreateInfo));
-		linkedRenderEngine->textures[*textureType.first]->uploadToRAM(texture);
-	}
+    // load all textures despite embedded state
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes) {
+        while (texturePath.length == 0 && textureIndex < textureCount)
+            material->GetTexture(textureType.second, textureIndex++, &texturePath);
+        texture = const_cast<aiTexture *>(scene->GetEmbeddedTexture(texturePath.C_Str()));
+        if (texture == nullptr || texture->mHeight != 0) {  // is the texture not an embedded texture?
+            texture = new aiTexture;
+            texture->mFilename =
+              directory.substr(0, directory.find_last_of('/')) + "/textures/" + texturePath.C_Str();
+            texture->mHeight = 1;  // flag texture as not embedded
+        }
+        *textureType.first = linkedRenderEngine->textures.size();
+
+        linkedRenderEngine->textures.push_back(std::make_shared<IETexture>(linkedRenderEngine, &imageCreateInfo));
+        linkedRenderEngine->textures[*textureType.first]->uploadToRAM(texture);
+    }
 }
 
 void IEMaterial::_vulkanLoadFromDiskToRAM(const std::string &directory, const aiScene *scene, uint32_t index) {
-	aiMaterial *material = scene->mMaterials[index];
+    aiMaterial *material = scene->mMaterials[index];
 
-	// find all textures in scene including embedded textures
-	textureCount = 0;
-	uint32_t thisCount;
-	/**@todo Build a system that tracks duplicate textures and only keeps one copy in memory.*/
-	for (size_t i = 0; i < supportedTextureTypes.size(); ++i) {
-		thisCount = material->GetTextureCount(supportedTextureTypes[i].second);
-		if (thisCount == 0) {
-			supportedTextureTypes.erase(supportedTextureTypes.begin() + i--);
-		}
-		textureCount += thisCount;
-	}
-	linkedRenderEngine->textures.reserve(linkedRenderEngine->textures.size() + textureCount);
+    // find all textures in scene including embedded textures
+    textureCount = 0;
+    uint32_t thisCount;
+    /**@todo Build a system that tracks duplicate textures and only keeps one copy in memory.*/
+    for (size_t i = 0; i < supportedTextureTypes.size(); ++i) {
+        thisCount = material->GetTextureCount(supportedTextureTypes[i].second);
+        if (thisCount == 0) supportedTextureTypes.erase(supportedTextureTypes.begin() + i--);
+        textureCount += thisCount;
+    }
+    linkedRenderEngine->textures.reserve(linkedRenderEngine->textures.size() + textureCount);
 
-	aiString texturePath{};
-	std::string data{};
-	aiTexture *texture;
-	uint32_t textureIndex{0};
-	IETexture::CreateInfo imageCreateInfo{};
+    aiString              texturePath{};
+    std::string           data{};
+    aiTexture            *texture;
+    uint32_t              textureIndex{0};
+    IETexture::CreateInfo imageCreateInfo{};
 
-	// load all textures despite embedded state
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		while (texturePath.length == 0 && textureIndex < textureCount) {
-			material->GetTexture(textureType.second, textureIndex++, &texturePath);
-		}
-		texture = const_cast<aiTexture *>(scene->GetEmbeddedTexture(texturePath.C_Str()));
-		if (texture == nullptr || texture->mHeight != 0) {  // is the texture not an embedded texture?
-			texture = new aiTexture;
-			texture->mFilename = directory.substr(0, directory.find_last_of('/')) + "/textures/" + texturePath.C_Str();
-			texture->mHeight = 1;  // flag texture as not embedded
-		}
-		*textureType.first = linkedRenderEngine->textures.size();
+    // load all textures despite embedded state
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes) {
+        while (texturePath.length == 0 && textureIndex < textureCount)
+            material->GetTexture(textureType.second, textureIndex++, &texturePath);
+        texture = const_cast<aiTexture *>(scene->GetEmbeddedTexture(texturePath.C_Str()));
+        if (texture == nullptr || texture->mHeight != 0) {  // is the texture not an embedded texture?
+            texture = new aiTexture;
+            texture->mFilename =
+              directory.substr(0, directory.find_last_of('/')) + "/textures/" + texturePath.C_Str();
+            texture->mHeight = 1;  // flag texture as not embedded
+        }
+        *textureType.first = linkedRenderEngine->textures.size();
 
-		linkedRenderEngine->textures.push_back(std::make_shared<IETexture>(linkedRenderEngine, &imageCreateInfo));
-		linkedRenderEngine->textures[*textureType.first]->uploadToRAM(texture);
-	}
+        linkedRenderEngine->textures.push_back(std::make_shared<IETexture>(linkedRenderEngine, &imageCreateInfo));
+        linkedRenderEngine->textures[*textureType.first]->uploadToRAM(texture);
+    }
 }
-
 
 std::function<void(IEMaterial &)> IEMaterial::_loadFromRAMToVRAM{nullptr};
 
 void IEMaterial::loadFromRAMToVRAM() {
-	_loadFromRAMToVRAM(*this);
+    _loadFromRAMToVRAM(*this);
 }
 
 void IEMaterial::_openglLoadFromRAMToVRAM() {
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		linkedRenderEngine->textures[*textureType.first]->uploadToVRAM();
-	}
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes)
+        linkedRenderEngine->textures[*textureType.first]->uploadToVRAM();
 }
 
 void IEMaterial::_vulkanLoadFromRAMToVRAM() {
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		linkedRenderEngine->textures[*textureType.first]->uploadToVRAM();
-	}
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes)
+        linkedRenderEngine->textures[*textureType.first]->uploadToVRAM();
 }
-
 
 std::function<void(IEMaterial &)> IEMaterial::_unloadFromVRAM{nullptr};
 
 void IEMaterial::unloadFromVRAM() {
-	_unloadFromVRAM(*this);
+    _unloadFromVRAM(*this);
 }
 
 void IEMaterial::_openglUnloadFromVRAM() {
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		linkedRenderEngine->textures[*textureType.first]->unloadFromVRAM();
-	}
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes)
+        linkedRenderEngine->textures[*textureType.first]->unloadFromVRAM();
 }
 
 void IEMaterial::_vulkanUnloadFromVRAM() {
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		linkedRenderEngine->textures[*textureType.first]->unloadFromVRAM();
-	}
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes)
+        linkedRenderEngine->textures[*textureType.first]->unloadFromVRAM();
 }
 
-
-/**@todo Keep two numbers of materials owning texture in IETexture. Decrease the appropriate number whenever a material is unloaded from RAM or VRAM. Delete texture from appropriate memory type when number is zero.*/
+/**@todo Keep two numbers of materials owning texture in IETexture. Decrease the appropriate number whenever a
+ * material is unloaded from RAM or VRAM. Delete texture from appropriate memory type when number is zero.*/
 
 std::function<void(IEMaterial &)> IEMaterial::_unloadFromRAM{nullptr};
 
 void IEMaterial::unloadFromRAM() {
-	_unloadFromRAM(*this);
+    _unloadFromRAM(*this);
 }
 
 void IEMaterial::_openglUnloadFromRAM() {
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		linkedRenderEngine->textures[*textureType.first]->data.clear();
-	}
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes)
+        linkedRenderEngine->textures[*textureType.first]->data.clear();
 }
 
 void IEMaterial::_vulkanUnloadFromRAM() {
-	for (std::pair<uint32_t *, aiTextureType> textureType: supportedTextureTypes) {
-		linkedRenderEngine->textures[*textureType.first]->data.clear();
-	}
+    for (std::pair<uint32_t *, aiTextureType> textureType : supportedTextureTypes)
+        linkedRenderEngine->textures[*textureType.first]->data.clear();
 }
-

--- a/src/GraphicsModule/Renderable/IEMaterial.hpp
+++ b/src/GraphicsModule/Renderable/IEMaterial.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <iostream>
 #include "assimp/material.h"
-#include "stb_image.h"
-#include "assimp/texture.h"
 #include "assimp/scene.h"
-#include <unordered_map>
-#include <string>
+#include "assimp/texture.h"
 #include "Image/IETexture.hpp"
+#include "stb_image.h"
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
 
 #define GLM_FORCE_RADIANS
 
@@ -17,65 +18,65 @@ class IEMesh;
 
 class IEMaterial {
 public:
-	uint32_t textureCount{};
-	uint32_t diffuseTextureIndex{};
-	glm::vec4 diffuseColor{1.0F, 1.0F, 1.0F, 1.0F};
-	IERenderEngine *linkedRenderEngine{};
+    uint32_t        textureCount{};
+    uint32_t        diffuseTextureIndex{};
+    glm::vec4       diffuseColor{1.0F, 1.0F, 1.0F, 1.0F};
+    IERenderEngine *linkedRenderEngine{};
 
-	IEMaterial() = default;
+    IEMaterial() = default;
 
-	explicit IEMaterial(IERenderEngine *engineLink);
+    explicit IEMaterial(IERenderEngine *engineLink);
 
-	static void setAPI(const IEAPI &API);
-
-
-	static std::function<void(IEMaterial &)> _create;
-
-	void create(IERenderEngine *);
-
-	void _openglCreate();
-
-	void _vulkanCreate();
+    static void setAPI(const IEAPI &API);
 
 
-	static std::function<void(IEMaterial &, const std::string &, const aiScene *, uint32_t)> _loadFromDiskToRAM;
+    static std::function<void(IEMaterial &)> _create;
 
-	void loadFromDiskToRAM(const std::string &, const aiScene *, uint32_t);
+    void create(IERenderEngine *);
 
-	void _openglLoadFromDiskToRAM(const std::string &, const aiScene *, uint32_t);
+    void _openglCreate();
 
-	void _vulkanLoadFromDiskToRAM(const std::string &, const aiScene *, uint32_t);
-
-
-	static std::function<void(IEMaterial &)> _loadFromRAMToVRAM;
-
-	void loadFromRAMToVRAM();
-
-	void _openglLoadFromRAMToVRAM();
-
-	void _vulkanLoadFromRAMToVRAM();
+    void _vulkanCreate();
 
 
-	static std::function<void(IEMaterial &)> _unloadFromVRAM;
+    static std::function<void(IEMaterial &, const std::string &, const aiScene *, uint32_t)> _loadFromDiskToRAM;
 
-	void unloadFromVRAM();
+    void loadFromDiskToRAM(const std::string &, const aiScene *, uint32_t);
 
-	void _openglUnloadFromVRAM();
+    void _openglLoadFromDiskToRAM(const std::string &, const aiScene *, uint32_t);
 
-	void _vulkanUnloadFromVRAM();
+    void _vulkanLoadFromDiskToRAM(const std::string &, const aiScene *, uint32_t);
 
 
-	static std::function<void(IEMaterial &)> _unloadFromRAM;
+    static std::function<void(IEMaterial &)> _loadFromRAMToVRAM;
 
-	void unloadFromRAM();
+    void loadFromRAMToVRAM();
 
-	void _openglUnloadFromRAM();
+    void _openglLoadFromRAMToVRAM();
 
-	void _vulkanUnloadFromRAM();
+    void _vulkanLoadFromRAMToVRAM();
+
+
+    static std::function<void(IEMaterial &)> _unloadFromVRAM;
+
+    void unloadFromVRAM();
+
+    void _openglUnloadFromVRAM();
+
+    void _vulkanUnloadFromVRAM();
+
+
+    static std::function<void(IEMaterial &)> _unloadFromRAM;
+
+    void unloadFromRAM();
+
+    void _openglUnloadFromRAM();
+
+    void _vulkanUnloadFromRAM();
 
 private:
-	std::vector<std::pair<uint32_t *, aiTextureType>> supportedTextureTypes = {
-			{&diffuseTextureIndex, aiTextureType_DIFFUSE},
-			{&diffuseTextureIndex, aiTextureType_BASE_COLOR},
-	};
+    std::vector<std::pair<uint32_t *, aiTextureType>> supportedTextureTypes = {
+      {&diffuseTextureIndex, aiTextureType_DIFFUSE   },
+      {&diffuseTextureIndex, aiTextureType_BASE_COLOR},
+    };
 };

--- a/src/GraphicsModule/Renderable/IEMesh.cpp
+++ b/src/GraphicsModule/Renderable/IEMesh.cpp
@@ -1,312 +1,316 @@
 #include "IEMesh.hpp"
+
 #include "Buffer/IEBuffer.hpp"
 #include "Core/LogModule/IELogger.hpp"
 #include "IERenderEngine.hpp"
 
 IEMesh::IEMesh(IERenderEngine *engineLink) {
-	create(engineLink);
+    create(engineLink);
 }
 
 void IEMesh::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_loadFromDiskToRAM = &IEMesh::_openglLoadFromDiskToRAM;
-		_loadFromRAMToVRAM = &IEMesh::_openglLoadFromRAMToVRAM;
-		_update = &IEMesh::_openglUpdate;
-		_unloadFromVRAM = &IEMesh::_openglUnloadFromVRAM;
-		_unloadFromRAM = &IEMesh::_openglUnloadFromRAM;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_loadFromDiskToRAM = &IEMesh::_vulkanLoadFromDiskToRAM;
-		_loadFromRAMToVRAM = &IEMesh::_vulkanLoadFromRAMToVRAM;
-		_update = &IEMesh::_vulkanUpdate;
-		_unloadFromVRAM = &IEMesh::_vulkanUnloadFromVRAM;
-		_unloadFromRAM = &IEMesh::_vulkanUnloadFromRAM;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _loadFromDiskToRAM = &IEMesh::_openglLoadFromDiskToRAM;
+        _loadFromRAMToVRAM = &IEMesh::_openglLoadFromRAMToVRAM;
+        _update            = &IEMesh::_openglUpdate;
+        _unloadFromVRAM    = &IEMesh::_openglUnloadFromVRAM;
+        _unloadFromRAM     = &IEMesh::_openglUnloadFromRAM;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _loadFromDiskToRAM = &IEMesh::_vulkanLoadFromDiskToRAM;
+        _loadFromRAMToVRAM = &IEMesh::_vulkanLoadFromRAMToVRAM;
+        _update            = &IEMesh::_vulkanUpdate;
+        _unloadFromVRAM    = &IEMesh::_vulkanUnloadFromVRAM;
+        _unloadFromRAM     = &IEMesh::_vulkanUnloadFromRAM;
+    }
 }
 
 void IEMesh::create(IERenderEngine *engineLink) {
-	linkedRenderEngine = engineLink;
-	vertexBuffer = std::make_shared<IEBuffer>();
-	indexBuffer = std::make_shared<IEBuffer>();
-	descriptorSet = std::make_shared<IEDescriptorSet>();
-	pipeline = std::make_shared<IEPipeline>();
-	material = std::make_shared<IEMaterial>();
-	material->create(linkedRenderEngine);
+    linkedRenderEngine = engineLink;
+    vertexBuffer       = std::make_shared<IEBuffer>();
+    indexBuffer        = std::make_shared<IEBuffer>();
+    descriptorSet      = std::make_shared<IEDescriptorSet>();
+    pipeline           = std::make_shared<IEPipeline>();
+    material           = std::make_shared<IEMaterial>();
+    material->create(linkedRenderEngine);
 }
-
 
 std::function<void(IEMesh &, const std::string &, const aiScene *, aiMesh *)> IEMesh::_loadFromDiskToRAM{nullptr};
 
 void IEMesh::loadFromDiskToRAM(const std::string &directory, const aiScene *scene, aiMesh *mesh) {
-	_loadFromDiskToRAM(*this, directory, scene, mesh);
+    _loadFromDiskToRAM(*this, directory, scene, mesh);
 }
 
 void IEMesh::_openglLoadFromDiskToRAM(const std::string &directory, const aiScene *scene, aiMesh *mesh) {
-// record indices
-	vertices.reserve(mesh->mNumVertices);
-	IEVertex temporaryVertex{};
-	for (size_t i = 0; i < mesh->mNumVertices; ++i) {
-		if (mesh->HasPositions()) {
-			temporaryVertex.position = {mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z};
-		}
-		if (mesh->HasNormals()) {
-			temporaryVertex.normal = {mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z};
-		}
-		if (mesh->HasTextureCoords(0)) {
-			temporaryVertex.textureCoordinates = {mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y};
-		}
-		if (mesh->HasVertexColors(0)) {
-			temporaryVertex.color = {mesh->mColors[0][i].a, mesh->mColors[0][i].r, mesh->mColors[0][i].g, mesh->mColors[0][i].b};
-		}
-		if (mesh->HasTangentsAndBitangents()) {
-			temporaryVertex.tangent = {mesh->mTangents[i].x, mesh->mTangents[i].y, mesh->mTangents[i].z};
-			temporaryVertex.biTangent = {mesh->mBitangents[i].x, mesh->mBitangents[i].y, mesh->mBitangents[i].z};
-		}
-		vertices.push_back(temporaryVertex);
-	}
+    // record indices
+    vertices.reserve(mesh->mNumVertices);
+    IEVertex temporaryVertex{};
+    for (size_t i = 0; i < mesh->mNumVertices; ++i) {
+        if (mesh->HasPositions())
+            temporaryVertex.position = {mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z};
+        if (mesh->HasNormals())
+            temporaryVertex.normal = {mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z};
+        if (mesh->HasTextureCoords(0))
+            temporaryVertex.textureCoordinates = {mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y};
+        if (mesh->HasVertexColors(0)) {
+            temporaryVertex.color =
+              {mesh->mColors[0][i].a, mesh->mColors[0][i].r, mesh->mColors[0][i].g, mesh->mColors[0][i].b};
+        }
+        if (mesh->HasTangentsAndBitangents()) {
+            temporaryVertex.tangent   = {mesh->mTangents[i].x, mesh->mTangents[i].y, mesh->mTangents[i].z};
+            temporaryVertex.biTangent = {mesh->mBitangents[i].x, mesh->mBitangents[i].y, mesh->mBitangents[i].z};
+        }
+        vertices.push_back(temporaryVertex);
+    }
 
-	// Create vertex buffer.
-	IEBuffer::CreateInfo vertexBufferCreateInfo{
-			.size=sizeof(vertices[0]) * vertices.size(),
-			.type=GL_ARRAY_BUFFER,
-	};
-	vertexBuffer->create(linkedRenderEngine, &vertexBufferCreateInfo);
-	vertexBuffer->uploadToRAM(vertices.data(), vertexBufferCreateInfo.size);
+    // Create vertex buffer.
+    IEBuffer::CreateInfo vertexBufferCreateInfo{
+      .size = sizeof(vertices[0]) * vertices.size(),
+      .type = GL_ARRAY_BUFFER,
+    };
+    vertexBuffer->create(linkedRenderEngine, &vertexBufferCreateInfo);
+    vertexBuffer->uploadToRAM(vertices.data(), vertexBufferCreateInfo.size);
 
-	// assuming all faces are triangles
-	triangleCount = mesh->mNumFaces;
+    // assuming all faces are triangles
+    triangleCount = mesh->mNumFaces;
 
-	// record vertices
-	indices.reserve(3UL * triangleCount);
-	size_t j;
-	for (size_t i = 0; i < triangleCount; ++i) {
-		if (mesh->mFaces[i].mNumIndices != 3) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-													 "Attempted to add a non-triangular face to a mesh! Try using the aiProcess_Triangulate flag.");
-		}
-		for (j = 0; j < mesh->mFaces[i].mNumIndices; ++j) {
-			indices.push_back(mesh->mFaces[i].mIndices[j]);
-		}
-	}
+    // record vertices
+    indices.reserve(3UL * triangleCount);
+    size_t j;
+    for (size_t i = 0; i < triangleCount; ++i) {
+        if (mesh->mFaces[i].mNumIndices != 3) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+              "Attempted to add a non-triangular face to a mesh! Try using the aiProcess_Triangulate flag."
+            );
+        }
+        for (j = 0; j < mesh->mFaces[i].mNumIndices; ++j) indices.push_back(mesh->mFaces[i].mIndices[j]);
+    }
 
-	// Create index buffer
-	IEBuffer::CreateInfo indexBufferCreateInfo{
-			.size=sizeof(indices[0]) * indices.size(),
-			.type=GL_ELEMENT_ARRAY_BUFFER,
-	};
-	indexBuffer->create(linkedRenderEngine, &indexBufferCreateInfo);
-	indexBuffer->uploadToRAM(indices.data(), indexBufferCreateInfo.size);
+    // Create index buffer
+    IEBuffer::CreateInfo indexBufferCreateInfo{
+      .size = sizeof(indices[0]) * indices.size(),
+      .type = GL_ELEMENT_ARRAY_BUFFER,
+    };
+    indexBuffer->create(linkedRenderEngine, &indexBufferCreateInfo);
+    indexBuffer->uploadToRAM(indices.data(), indexBufferCreateInfo.size);
 
-	// load material
-	material->loadFromDiskToRAM(directory, scene, mesh->mMaterialIndex);
+    // load material
+    material->loadFromDiskToRAM(directory, scene, mesh->mMaterialIndex);
 }
 
 void IEMesh::_vulkanLoadFromDiskToRAM(const std::string &directory, const aiScene *scene, aiMesh *mesh) {
-	// record indices
-	vertices.reserve(mesh->mNumVertices);
-	IEVertex temporaryVertex{};
-	for (size_t i = 0; i < mesh->mNumVertices; ++i) {
-		if (mesh->HasPositions()) {
-			temporaryVertex.position = {mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z};
-		}
-		if (mesh->HasNormals()) {
-			temporaryVertex.normal = {mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z};
-		}
-		if (mesh->HasTextureCoords(0)) {
-			temporaryVertex.textureCoordinates = {mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y};
-		}
-		if (mesh->HasVertexColors(0)) {
-			temporaryVertex.color = {mesh->mColors[0][i].a, mesh->mColors[0][i].r, mesh->mColors[0][i].g, mesh->mColors[0][i].b};
-		}
-		if (mesh->HasTangentsAndBitangents()) {
-			temporaryVertex.tangent = {mesh->mTangents[i].x, mesh->mTangents[i].y, mesh->mTangents[i].z};
-			temporaryVertex.biTangent = {mesh->mBitangents[i].x, mesh->mBitangents[i].y, mesh->mBitangents[i].z};
-		}
-		vertices.push_back(temporaryVertex);
-	}
+    // record indices
+    vertices.reserve(mesh->mNumVertices);
+    IEVertex temporaryVertex{};
+    for (size_t i = 0; i < mesh->mNumVertices; ++i) {
+        if (mesh->HasPositions())
+            temporaryVertex.position = {mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z};
+        if (mesh->HasNormals())
+            temporaryVertex.normal = {mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z};
+        if (mesh->HasTextureCoords(0))
+            temporaryVertex.textureCoordinates = {mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y};
+        if (mesh->HasVertexColors(0)) {
+            temporaryVertex.color =
+              {mesh->mColors[0][i].a, mesh->mColors[0][i].r, mesh->mColors[0][i].g, mesh->mColors[0][i].b};
+        }
+        if (mesh->HasTangentsAndBitangents()) {
+            temporaryVertex.tangent   = {mesh->mTangents[i].x, mesh->mTangents[i].y, mesh->mTangents[i].z};
+            temporaryVertex.biTangent = {mesh->mBitangents[i].x, mesh->mBitangents[i].y, mesh->mBitangents[i].z};
+        }
+        vertices.push_back(temporaryVertex);
+    }
 
-	// Create vertex buffer.
-	IEBuffer::CreateInfo vertexBufferCreateInfo{
-			.size=sizeof(vertices[0]) * vertices.size(),
-			.usage=VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-			.allocationUsage=VMA_MEMORY_USAGE_CPU_TO_GPU,
-	};
-	vertexBuffer->create(linkedRenderEngine, &vertexBufferCreateInfo);
-	vertexBuffer->uploadToRAM(vertices.data(), vertexBufferCreateInfo.size);
+    // Create vertex buffer.
+    IEBuffer::CreateInfo vertexBufferCreateInfo{
+      .size            = sizeof(vertices[0]) * vertices.size(),
+      .usage           = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+      .allocationUsage = VMA_MEMORY_USAGE_CPU_TO_GPU,
+    };
+    vertexBuffer->create(linkedRenderEngine, &vertexBufferCreateInfo);
+    vertexBuffer->uploadToRAM(vertices.data(), vertexBufferCreateInfo.size);
 
-	// assuming all faces are triangles
-	triangleCount = mesh->mNumFaces;
+    // assuming all faces are triangles
+    triangleCount = mesh->mNumFaces;
 
-	// record vertices
-	indices.reserve(3UL * triangleCount);
-	size_t j;
-	for (size_t i = 0; i < triangleCount; ++i) {
-		if (mesh->mFaces[i].mNumIndices != 3) {
-			linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-													 "Attempted to add a non-triangular face to a mesh! Try using the aiProcess_Triangulate flag.");
-		}
-		for (j = 0; j < mesh->mFaces[i].mNumIndices; ++j) {
-			indices.push_back(mesh->mFaces[i].mIndices[j]);
-		}
-	}
+    // record vertices
+    indices.reserve(3UL * triangleCount);
+    size_t j;
+    for (size_t i = 0; i < triangleCount; ++i) {
+        if (mesh->mFaces[i].mNumIndices != 3) {
+            linkedRenderEngine->settings->logger.log(
+              ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+              "Attempted to add a non-triangular face to a mesh! Try using the aiProcess_Triangulate flag."
+            );
+        }
+        for (j = 0; j < mesh->mFaces[i].mNumIndices; ++j) indices.push_back(mesh->mFaces[i].mIndices[j]);
+    }
 
-	// Create index buffer
-	IEBuffer::CreateInfo indexBufferCreateInfo{
-			.size=sizeof(indices[0]) * indices.size(),
-			.usage=VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
-			.allocationUsage=VMA_MEMORY_USAGE_CPU_TO_GPU,
-	};
-	indexBuffer->create(linkedRenderEngine, &indexBufferCreateInfo);
-	indexBuffer->uploadToRAM(indices.data(), indexBufferCreateInfo.size);
+    // Create index buffer
+    IEBuffer::CreateInfo indexBufferCreateInfo{
+      .size            = sizeof(indices[0]) * indices.size(),
+      .usage           = VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+      .allocationUsage = VMA_MEMORY_USAGE_CPU_TO_GPU,
+    };
+    indexBuffer->create(linkedRenderEngine, &indexBufferCreateInfo);
+    indexBuffer->uploadToRAM(indices.data(), indexBufferCreateInfo.size);
 
-	// load material
-	material->loadFromDiskToRAM(directory, scene, mesh->mMaterialIndex);
+    // load material
+    material->loadFromDiskToRAM(directory, scene, mesh->mMaterialIndex);
 
-	// create descriptor set
-	IEDescriptorSet::CreateInfo descriptorSetCreateInfo{
-			.poolSizes={{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,         1},
-						{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1}},
-			.shaderStages={static_cast<VkShaderStageFlagBits>(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT),
-						   VK_SHADER_STAGE_FRAGMENT_BIT},
-			.data={std::nullopt, std::nullopt}
-	};
-	descriptorSet->create(linkedRenderEngine, &descriptorSetCreateInfo);
-	deletionQueue.emplace_back([&] { descriptorSet->destroy(); });
+    // create descriptor set
+    IEDescriptorSet::CreateInfo descriptorSetCreateInfo{
+      .poolSizes = {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1},                                                        {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1}},
+      .shaderStages =
+        {static_cast<VkShaderStageFlagBits>(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT),
+                    VK_SHADER_STAGE_FRAGMENT_BIT                                                                                                                 },
+      .data = {std::nullopt,                                                                                  std::nullopt                                  }
+    };
+    descriptorSet->create(linkedRenderEngine, &descriptorSetCreateInfo);
+    deletionQueue.emplace_back([&] { descriptorSet->destroy(); });
 }
-
 
 std::function<void(IEMesh &)> IEMesh::_loadFromRAMToVRAM{nullptr};
 
 void IEMesh::loadFromRAMToVRAM() {
-	_loadFromRAMToVRAM(*this);
+    _loadFromRAMToVRAM(*this);
 }
 
 void IEMesh::_openglLoadFromRAMToVRAM() {
-	material->loadFromRAMToVRAM();
+    material->loadFromRAMToVRAM();
 
-	vertexBuffer->uploadToVRAM();
+    vertexBuffer->uploadToVRAM();
 
-	indexBuffer->uploadToVRAM();
+    indexBuffer->uploadToVRAM();
 
-	shaders.resize(2);
-	shaders[0] = std::make_shared<IEShader>();
-	shaders[0]->create(linkedRenderEngine, new IEFile{"shaders/OpenGL/vertexShader.vert"});
-	shaders[1] = std::make_shared<IEShader>();
-	shaders[1]->create(linkedRenderEngine, new IEFile{"shaders/OpenGL/fragmentShader.frag"});
+    shaders.resize(2);
+    shaders[0] = std::make_shared<IEShader>();
+    shaders[0]->create(linkedRenderEngine, new IEFile{"shaders/OpenGL/vertexShader.vert"});
+    shaders[1] = std::make_shared<IEShader>();
+    shaders[1]->create(linkedRenderEngine, new IEFile{"shaders/OpenGL/fragmentShader.frag"});
 
-	pipeline->create(linkedRenderEngine, new IEPipeline::CreateInfo{
-			.shaders=shaders,
-	});
-	
-	glGenVertexArrays(1, &vertexArray);
-	glBindVertexArray(vertexArray);
-	
-	glBindBuffer(vertexBuffer->type, vertexBuffer->id);
-	glBindBuffer(indexBuffer->type, indexBuffer->id);
+    pipeline->create(
+      linkedRenderEngine,
+      new IEPipeline::CreateInfo{
+        .shaders = shaders,
+      }
+    );
 
-	IEVertex::useVertexAttributesWithProgram(pipeline->programID);
-	
-	glBindBuffer(vertexBuffer->type, 0);
+    glGenVertexArrays(1, &vertexArray);
+    glBindVertexArray(vertexArray);
+
+    glBindBuffer(vertexBuffer->type, vertexBuffer->id);
+    glBindBuffer(indexBuffer->type, indexBuffer->id);
+
+    IEVertex::useVertexAttributesWithProgram(pipeline->programID);
+
+    glBindBuffer(vertexBuffer->type, 0);
 }
 
 void IEMesh::_vulkanLoadFromRAMToVRAM() {
-	material->loadFromRAMToVRAM();
+    material->loadFromRAMToVRAM();
 
-	vertexBuffer->uploadToVRAM();
-	deletionQueue.emplace_back([&] { vertexBuffer->destroy(); });
+    vertexBuffer->uploadToVRAM();
+    deletionQueue.emplace_back([&] { vertexBuffer->destroy(); });
 
-	indexBuffer->uploadToVRAM();
-	deletionQueue.emplace_back([&] { indexBuffer->destroy(); });
+    indexBuffer->uploadToVRAM();
+    deletionQueue.emplace_back([&] { indexBuffer->destroy(); });
 
-	// Set up shaders
-	shaders.resize(2);
-	shaders[0] = std::make_shared<IEShader>();
-	shaders[0]->create(linkedRenderEngine, new IEFile{"shaders/Vulkan/vertexShader.vert.spv"});
-	shaders[1] = std::make_shared<IEShader>();
-	shaders[1]->create(linkedRenderEngine, new IEFile{"shaders/Vulkan/fragmentShader.frag.spv"});
+    // Set up shaders
+    shaders.resize(2);
+    shaders[0] = std::make_shared<IEShader>();
+    shaders[0]->create(linkedRenderEngine, new IEFile{"shaders/Vulkan/vertexShader.vert.spv"});
+    shaders[1] = std::make_shared<IEShader>();
+    shaders[1]->create(linkedRenderEngine, new IEFile{"shaders/Vulkan/fragmentShader.frag.spv"});
 
-	// Set up pipeline
-	pipeline->create(linkedRenderEngine, new IEPipeline::CreateInfo{
-			.shaders=shaders,
-			.descriptorSet=descriptorSet,
-			.renderPass=linkedRenderEngine->renderPass  /**@todo Make renderPass of pipeline adjustable.*/
-	});
+    // Set up pipeline
+    pipeline->create(
+      linkedRenderEngine,
+      new IEPipeline::CreateInfo{
+        .shaders       = shaders,
+        .descriptorSet = descriptorSet,
+        .renderPass    = linkedRenderEngine->renderPass /**@todo Make renderPass of pipeline adjustable.*/
+      }
+    );
 
-	// Set up descriptor set
-	linkedRenderEngine->textures[material->diffuseTextureIndex]->transitionLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-	descriptorSet->update({linkedRenderEngine->textures[material->diffuseTextureIndex].get()}, {1});
+    // Set up descriptor set
+    linkedRenderEngine->textures[material->diffuseTextureIndex]->transitionLayout(
+      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+    );
+    descriptorSet->update({linkedRenderEngine->textures[material->diffuseTextureIndex].get()}, {1});
 }
-
 
 std::function<void(IEMesh &, uint32_t)> IEMesh::_update{nullptr};
 
 void IEMesh::update(uint32_t commandBufferIndex) {
-	_update(*this, commandBufferIndex);
+    _update(*this, commandBufferIndex);
 }
 
 void IEMesh::_openglUpdate(uint32_t commandBufferIndex) {
-	// Set shader program
-	glUseProgram(pipeline->programID);
-	
-	// Set vertices
-	glBindVertexArray(vertexArray);
-	glBindBuffer(indexBuffer->type, indexBuffer->id);
-	
-	// Update texture
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, linkedRenderEngine->textures[material->diffuseTextureIndex]->id);
-	
-	// Set active texture for diffuseTexture in shader
-	glUniform1i(glGetUniformLocation(pipeline->programID, "diffuseTexture"), 0);  // Magic number is the active texture.
-	
-	// Draw mesh
-	glDrawElements(GL_TRIANGLES, (GLsizei) indices.size(), GL_UNSIGNED_INT, nullptr);
-	
-	//Reset All
-	glUseProgram(0);
-	glBindVertexArray(0);
-	glBindBuffer(indexBuffer->type, 0);
-	glBindTexture(GL_TEXTURE_2D, 0);
-	
+    // Set shader program
+    glUseProgram(pipeline->programID);
+
+    // Set vertices
+    glBindVertexArray(vertexArray);
+    glBindBuffer(indexBuffer->type, indexBuffer->id);
+
+    // Update texture
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, linkedRenderEngine->textures[material->diffuseTextureIndex]->id);
+
+    // Set active texture for diffuseTexture in shader
+    glUniform1i(
+      glGetUniformLocation(pipeline->programID, "diffuseTexture"),
+      0
+    );  // Magic number is the active texture.
+
+    // Draw mesh
+    glDrawElements(GL_TRIANGLES, (GLsizei) indices.size(), GL_UNSIGNED_INT, nullptr);
+
+    // Reset All
+    glUseProgram(0);
+    glBindVertexArray(0);
+    glBindBuffer(indexBuffer->type, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 void IEMesh::_vulkanUpdate(uint32_t commandBufferIndex) {
-	std::array<VkDeviceSize, 1> offsets{0};
-	linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)->recordBindVertexBuffers(0, 1, {vertexBuffer}, offsets.data());
-	linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)->recordBindIndexBuffer(indexBuffer, 0, VK_INDEX_TYPE_UINT32);
-	linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)->recordBindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-	linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)->recordBindDescriptorSets(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline, 0,
-																								 {descriptorSet}, {});
-	linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)->recordDrawIndexed(indices.size(), 1, 0, 0, 0);
+    std::array<VkDeviceSize, 1> offsets{0};
+    linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)
+      ->recordBindVertexBuffers(0, 1, {vertexBuffer}, offsets.data());
+    linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)
+      ->recordBindIndexBuffer(indexBuffer, 0, VK_INDEX_TYPE_UINT32);
+    linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)
+      ->recordBindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)
+      ->recordBindDescriptorSets(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline, 0, {descriptorSet}, {});
+    linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex)
+      ->recordDrawIndexed(indices.size(), 1, 0, 0, 0);
 }
-
 
 std::function<void(IEMesh &)> IEMesh::_unloadFromVRAM{nullptr};
 
 void IEMesh::unloadFromVRAM() {
-	_unloadFromVRAM(*this);
+    _unloadFromVRAM(*this);
 }
 
 void IEMesh::_openglUnloadFromVRAM() {
-
 }
 
 void IEMesh::_vulkanUnloadFromVRAM() {
-	vertexBuffer->unloadFromVRAM();
-	indexBuffer->unloadFromVRAM();
+    vertexBuffer->unloadFromVRAM();
+    indexBuffer->unloadFromVRAM();
 }
-
 
 std::function<void(IEMesh &)> IEMesh::_unloadFromRAM{nullptr};
 
 void IEMesh::unloadFromRAM() {
-	_unloadFromRAM(*this);
+    _unloadFromRAM(*this);
 }
 
 void IEMesh::_openglUnloadFromRAM() {
-
 }
 
 void IEMesh::_vulkanUnloadFromRAM() {
-	vertices.clear();
-	indices.clear();
+    vertices.clear();
+    indices.clear();
 }

--- a/src/GraphicsModule/Renderable/IEMesh.hpp
+++ b/src/GraphicsModule/Renderable/IEMesh.hpp
@@ -1,82 +1,83 @@
 #pragma once
 
-#include <cstdint>
-#include <vector>
-#include "IEVertex.hpp"
-#include "IEMaterial.hpp"
+#include "Buffer/IEBuffer.hpp"
 #include "GraphicsModule/Shader/IEDescriptorSet.hpp"
 #include "GraphicsModule/Shader/IEPipeline.hpp"
-#include "Buffer/IEBuffer.hpp"
+#include "IEMaterial.hpp"
+#include "IEVertex.hpp"
+
+#include <cstdint>
+#include <vector>
 
 class IERenderEngine;
 
 class IEMesh {
 public:
-	IEMesh() = default;
+    IEMesh() = default;
 
-	explicit IEMesh(IERenderEngine *);
+    explicit IEMesh(IERenderEngine *);
 
-	static void setAPI(const IEAPI &API);
-
-
-	void create(IERenderEngine *);
+    static void setAPI(const IEAPI &API);
 
 
-	static std::function<void(IEMesh &, const std::string &, const aiScene *, aiMesh *)> _loadFromDiskToRAM;
-
-	void loadFromDiskToRAM(const std::string &, const aiScene *, aiMesh *);
-
-	void _openglLoadFromDiskToRAM(const std::string &, const aiScene *, aiMesh *);
-
-	void _vulkanLoadFromDiskToRAM(const std::string &, const aiScene *, aiMesh *);
+    void create(IERenderEngine *);
 
 
-	static std::function<void(IEMesh &)> _loadFromRAMToVRAM;
+    static std::function<void(IEMesh &, const std::string &, const aiScene *, aiMesh *)> _loadFromDiskToRAM;
 
-	void loadFromRAMToVRAM();
+    void loadFromDiskToRAM(const std::string &, const aiScene *, aiMesh *);
 
-	void _openglLoadFromRAMToVRAM();
+    void _openglLoadFromDiskToRAM(const std::string &, const aiScene *, aiMesh *);
 
-	void _vulkanLoadFromRAMToVRAM();
-
-
-	static std::function<void(IEMesh &, uint32_t)> _update;
-
-	void update(uint32_t);
-
-	void _openglUpdate(uint32_t);
-
-	void _vulkanUpdate(uint32_t);
+    void _vulkanLoadFromDiskToRAM(const std::string &, const aiScene *, aiMesh *);
 
 
-	static std::function<void(IEMesh &)> _unloadFromVRAM;
+    static std::function<void(IEMesh &)> _loadFromRAMToVRAM;
 
-	void unloadFromVRAM();
+    void loadFromRAMToVRAM();
 
-	void _openglUnloadFromVRAM();
+    void _openglLoadFromRAMToVRAM();
 
-	void _vulkanUnloadFromVRAM();
-
-
-	static std::function<void(IEMesh &)> _unloadFromRAM;
-
-	void unloadFromRAM();
-
-	void _openglUnloadFromRAM();
-
-	void _vulkanUnloadFromRAM();
+    void _vulkanLoadFromRAMToVRAM();
 
 
-	IERenderEngine *linkedRenderEngine{};
-	std::shared_ptr<IEDescriptorSet> descriptorSet{};
-	std::shared_ptr<IEPipeline> pipeline{};
-	std::vector<IEVertex> vertices{};
-	std::vector<uint32_t> indices{};
-	std::shared_ptr<IEBuffer> vertexBuffer{};
-	uint32_t triangleCount{};
-	std::vector<std::shared_ptr<IEShader>> shaders{};  // Should be moved to material
-	std::shared_ptr<IEBuffer> indexBuffer{};
-	std::shared_ptr<IEMaterial> material{};
-	std::vector<std::function<void()>> deletionQueue{};
-	GLuint vertexArray{};
+    static std::function<void(IEMesh &, uint32_t)> _update;
+
+    void update(uint32_t);
+
+    void _openglUpdate(uint32_t);
+
+    void _vulkanUpdate(uint32_t);
+
+
+    static std::function<void(IEMesh &)> _unloadFromVRAM;
+
+    void unloadFromVRAM();
+
+    void _openglUnloadFromVRAM();
+
+    void _vulkanUnloadFromVRAM();
+
+
+    static std::function<void(IEMesh &)> _unloadFromRAM;
+
+    void unloadFromRAM();
+
+    void _openglUnloadFromRAM();
+
+    void _vulkanUnloadFromRAM();
+
+
+    IERenderEngine                        *linkedRenderEngine{};
+    std::shared_ptr<IEDescriptorSet>       descriptorSet{};
+    std::shared_ptr<IEPipeline>            pipeline{};
+    std::vector<IEVertex>                  vertices{};
+    std::vector<uint32_t>                  indices{};
+    std::shared_ptr<IEBuffer>              vertexBuffer{};
+    uint32_t                               triangleCount{};
+    std::vector<std::shared_ptr<IEShader>> shaders{};  // Should be moved to material
+    std::shared_ptr<IEBuffer>              indexBuffer{};
+    std::shared_ptr<IEMaterial>            material{};
+    std::vector<std::function<void()>>     deletionQueue{};
+    GLuint                                 vertexArray{};
 };

--- a/src/GraphicsModule/Renderable/IERenderable.cpp
+++ b/src/GraphicsModule/Renderable/IERenderable.cpp
@@ -2,242 +2,243 @@
 #include "IERenderable.hpp"
 
 /* Include dependencies within this module. */
-#include "IERenderEngine.hpp"
 #include "IEMesh.hpp"
+#include "IERenderEngine.hpp"
 
 /* Include external dependencies. */
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 
 #define GLM_FORCE_RADIANS
+
 #include <glm/glm.hpp>
-#include <glm/gtx/euler_angles.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <glm/gtx/euler_angles.hpp>
 
 IERenderable::IERenderable(IERenderEngine *engineLink, const std::string &filePath) {
-	create(engineLink, filePath);
+    create(engineLink, filePath);
 }
 
 void IERenderable::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_create = &IERenderable::_openglCreate;
-		_update = &IERenderable::_openglUpdate;
-		_loadFromDiskToRAM = &IERenderable::_openglLoadFromDiskToRAM;
-		_loadFromRAMToVRAM = &IERenderable::_openglLoadFromRAMToVRAM;
-		_unloadFromVRAM = &IERenderable::_openglUnloadFromVRAM;
-		_unloadFromRAM = &IERenderable::_openglUnloadFromRAM;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_create = &IERenderable::_vulkanCreate;
-		_update = &::IERenderable::_vulkanUpdate;
-		_loadFromDiskToRAM = &IERenderable::_vulkanLoadFromDiskToRAM;
-		_loadFromRAMToVRAM = &IERenderable::_vulkanLoadFromRAMToVRAM;
-		_unloadFromVRAM = &IERenderable::_vulkanUnloadFromVRAM;
-		_unloadFromRAM = &IERenderable::_vulkanUnloadFromRAM;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _create            = &IERenderable::_openglCreate;
+        _update            = &IERenderable::_openglUpdate;
+        _loadFromDiskToRAM = &IERenderable::_openglLoadFromDiskToRAM;
+        _loadFromRAMToVRAM = &IERenderable::_openglLoadFromRAMToVRAM;
+        _unloadFromVRAM    = &IERenderable::_openglUnloadFromVRAM;
+        _unloadFromRAM     = &IERenderable::_openglUnloadFromRAM;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _create            = &IERenderable::_vulkanCreate;
+        _update            = &::IERenderable::_vulkanUpdate;
+        _loadFromDiskToRAM = &IERenderable::_vulkanLoadFromDiskToRAM;
+        _loadFromRAMToVRAM = &IERenderable::_vulkanLoadFromRAMToVRAM;
+        _unloadFromVRAM    = &IERenderable::_vulkanUnloadFromVRAM;
+        _unloadFromRAM     = &IERenderable::_vulkanUnloadFromRAM;
+    }
 }
-
 
 std::function<void(IERenderable &, IERenderEngine *, const std::string &)> IERenderable::_create{nullptr};
 
 void IERenderable::create(IERenderEngine *engineLink, const std::string &filePath) {
-	linkedRenderEngine = engineLink;
-	directory = filePath.substr(0, filePath.find_last_of('/'));
-	modelName = filePath.substr(filePath.find_last_of('/'));
-	_create(*this, engineLink, filePath);
-	status = IE_RENDERABLE_STATE_UNLOADED;
+    linkedRenderEngine = engineLink;
+    directory          = filePath.substr(0, filePath.find_last_of('/'));
+    modelName          = filePath.substr(filePath.find_last_of('/'));
+    _create(*this, engineLink, filePath);
+    status = IE_RENDERABLE_STATE_UNLOADED;
 }
 
 void IERenderable::_openglCreate(IERenderEngine *engineLink, const std::string &filePath) {
-	linkedRenderEngine = engineLink;
-	for (IEMesh &mesh: meshes) {
-		mesh.create(linkedRenderEngine);
-	}
+    linkedRenderEngine = engineLink;
+    for (IEMesh &mesh : meshes) mesh.create(linkedRenderEngine);
 
-	IEBuffer::CreateInfo modelBufferCreateInfo{
-			.size=sizeof(IEUniformBufferObject),
-			.type=GL_ARRAY_BUFFER,
-	};
-	modelBuffer.create(linkedRenderEngine, &modelBufferCreateInfo);
+    IEBuffer::CreateInfo modelBufferCreateInfo{
+      .size = sizeof(IEUniformBufferObject),
+      .type = GL_ARRAY_BUFFER,
+    };
+    modelBuffer.create(linkedRenderEngine, &modelBufferCreateInfo);
 }
 
 void IERenderable::_vulkanCreate(IERenderEngine *engineLink, const std::string &filePath) {
-	linkedRenderEngine = engineLink;
-	for (IEMesh &mesh: meshes) {
-		mesh.create(linkedRenderEngine);
-	}
+    linkedRenderEngine = engineLink;
+    for (IEMesh &mesh : meshes) mesh.create(linkedRenderEngine);
 
-	IEBuffer::CreateInfo modelBufferCreateInfo{
-			.size=sizeof(IEUniformBufferObject),
-			.usage=VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-			.allocationUsage=VMA_MEMORY_USAGE_CPU_TO_GPU
-	};
-	modelBuffer.create(linkedRenderEngine, &modelBufferCreateInfo);
+    IEBuffer::CreateInfo modelBufferCreateInfo{
+      .size            = sizeof(IEUniformBufferObject),
+      .usage           = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+      .allocationUsage = VMA_MEMORY_USAGE_CPU_TO_GPU};
+    modelBuffer.create(linkedRenderEngine, &modelBufferCreateInfo);
 
-	// Prepare a command buffer for use by this object during creation
-	commandBufferIndex = linkedRenderEngine->graphicsCommandPool->commandBuffers.size();
-	linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex);
+    // Prepare a command buffer for use by this object during creation
+    commandBufferIndex = linkedRenderEngine->graphicsCommandPool->commandBuffers.size();
+    linkedRenderEngine->graphicsCommandPool->index(commandBufferIndex);
 }
-
 
 std::function<void(IERenderable &)> IERenderable::_loadFromDiskToRAM{nullptr};
 
 void IERenderable::loadFromDiskToRAM() {
-	if (status == IE_RENDERABLE_STATE_UNLOADED) {
-		_loadFromDiskToRAM(*this);
-		status = IE_RENDERABLE_STATE_IN_RAM;
-	}
+    if (status == IE_RENDERABLE_STATE_UNLOADED) {
+        _loadFromDiskToRAM(*this);
+        status = IE_RENDERABLE_STATE_IN_RAM;
+    }
 }
 
 void IERenderable::_openglLoadFromDiskToRAM() {
-	// Read input file
-	const aiScene *scene = importer.ReadFile(directory + modelName, aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_OptimizeMeshes | aiProcess_RemoveRedundantMaterials | aiProcess_JoinIdenticalVertices | aiProcess_PreTransformVertices | aiProcess_SortByPType | aiProcess_GenUVCoords | aiProcess_GenNormals | aiProcess_ValidateDataStructure | aiProcess_ImproveCacheLocality | aiProcess_FixInfacingNormals | aiProcess_FindDegenerates | aiProcess_FindInvalidData | aiProcess_FindInstances | aiProcess_Debone);
-	if ((scene == nullptr) || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0U) || (scene->mRootNode == nullptr)) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
-												 "Failed to prepare scene from file: " + std::string(directory + modelName) + "\t\tError: " + importer.GetErrorString());
-	}
+    // Read input file
+    const aiScene *scene = importer.ReadFile(
+      directory + modelName,
+      aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_OptimizeMeshes | aiProcess_RemoveRedundantMaterials |
+        aiProcess_JoinIdenticalVertices | aiProcess_PreTransformVertices | aiProcess_SortByPType |
+        aiProcess_GenUVCoords | aiProcess_GenNormals | aiProcess_ValidateDataStructure |
+        aiProcess_ImproveCacheLocality | aiProcess_FixInfacingNormals | aiProcess_FindDegenerates |
+        aiProcess_FindInvalidData | aiProcess_FindInstances | aiProcess_Debone
+    );
+    if ((scene == nullptr) || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0U) || (scene->mRootNode == nullptr)) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Failed to prepare scene from file: " + std::string(directory + modelName) +
+            "\t\tError: " + importer.GetErrorString()
+        );
+    }
 
-	meshes.resize(scene->mNumMeshes);
-	uint32_t meshIndex = 0;
+    meshes.resize(scene->mNumMeshes);
+    uint32_t meshIndex = 0;
 
-	// import all meshes
-	for (IEMesh &mesh: meshes) {
-		mesh.create(linkedRenderEngine);
-		mesh.loadFromDiskToRAM(directory, scene, scene->mMeshes[meshIndex++]);
-	}
+    // import all meshes
+    for (IEMesh &mesh : meshes) {
+        mesh.create(linkedRenderEngine);
+        mesh.loadFromDiskToRAM(directory, scene, scene->mMeshes[meshIndex++]);
+    }
 
-	modelBuffer.uploadToRAM(std::vector<char>{sizeof(glm::mat4)});
+    modelBuffer.uploadToRAM(std::vector<char>{sizeof(glm::mat4)});
 }
 
 void IERenderable::_vulkanLoadFromDiskToRAM() {
-	// Read input file
-	const aiScene *scene = importer.ReadFile(directory + modelName, aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_OptimizeMeshes | aiProcess_RemoveRedundantMaterials | aiProcess_JoinIdenticalVertices | aiProcess_PreTransformVertices | aiProcess_SortByPType | aiProcess_GenUVCoords | aiProcess_GenNormals | aiProcess_ValidateDataStructure | aiProcess_ImproveCacheLocality | aiProcess_FixInfacingNormals | aiProcess_FindDegenerates | aiProcess_FindInvalidData | aiProcess_FindInstances | aiProcess_Debone);
-	if ((scene == nullptr) || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0U) || (scene->mRootNode == nullptr)) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-												 "Failed to prepare scene from file: " + std::string(directory + modelName) + "\t\tError: " + importer.GetErrorString());
-	}
+    // Read input file
+    const aiScene *scene = importer.ReadFile(
+      directory + modelName,
+      aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_OptimizeMeshes | aiProcess_RemoveRedundantMaterials |
+        aiProcess_JoinIdenticalVertices | aiProcess_PreTransformVertices | aiProcess_SortByPType |
+        aiProcess_GenUVCoords | aiProcess_GenNormals | aiProcess_ValidateDataStructure |
+        aiProcess_ImproveCacheLocality | aiProcess_FixInfacingNormals | aiProcess_FindDegenerates |
+        aiProcess_FindInvalidData | aiProcess_FindInstances | aiProcess_Debone
+    );
+    if ((scene == nullptr) || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0U) || (scene->mRootNode == nullptr)) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to prepare scene from file: " + std::string(directory + modelName) +
+            "\t\tError: " + importer.GetErrorString()
+        );
+    }
 
-	meshes.resize(scene->mNumMeshes);
-	uint32_t meshIndex = 0;
+    meshes.resize(scene->mNumMeshes);
+    uint32_t meshIndex = 0;
 
-	// import all meshes
-	for (IEMesh &mesh: meshes) {
-		mesh.create(linkedRenderEngine);
-		mesh.loadFromDiskToRAM(directory, scene, scene->mMeshes[meshIndex++]);
-	}
+    // import all meshes
+    for (IEMesh &mesh : meshes) {
+        mesh.create(linkedRenderEngine);
+        mesh.loadFromDiskToRAM(directory, scene, scene->mMeshes[meshIndex++]);
+    }
 
-	modelBuffer.uploadToRAM(std::vector<char>{sizeof(glm::mat4)});
+    modelBuffer.uploadToRAM(std::vector<char>{sizeof(glm::mat4)});
 }
-
 
 std::function<void(IERenderable &)> IERenderable::_loadFromRAMToVRAM{nullptr};
 
 void IERenderable::loadFromRAMToVRAM() {
-	if (status == IE_RENDERABLE_STATE_IN_RAM) {
-		_loadFromRAMToVRAM(*this);
-		status = static_cast<IERenderableStatus>(status | IE_RENDERABLE_STATE_IN_VRAM);
-	}
+    if (status == IE_RENDERABLE_STATE_IN_RAM) {
+        _loadFromRAMToVRAM(*this);
+        status = static_cast<IERenderableStatus>(status | IE_RENDERABLE_STATE_IN_VRAM);
+    }
 }
 
 void IERenderable::_openglLoadFromRAMToVRAM() {
-	for (IEMesh &mesh: meshes) {
-		mesh.loadFromRAMToVRAM();
-	}
-	modelBuffer.uploadToVRAM();
+    for (IEMesh &mesh : meshes) mesh.loadFromRAMToVRAM();
+    modelBuffer.uploadToVRAM();
 }
 
 void IERenderable::_vulkanLoadFromRAMToVRAM() {
-	for (IEMesh &mesh: meshes) {
-		mesh.loadFromRAMToVRAM();
-	}
-	modelBuffer.uploadToVRAM();
+    for (IEMesh &mesh : meshes) mesh.loadFromRAMToVRAM();
+    modelBuffer.uploadToVRAM();
 }
-
 
 std::function<void(IERenderable &, const IECamera &, float, uint32_t)> IERenderable::_update{nullptr};
 
 void IERenderable::update(uint32_t renderCommandBufferIndex) {
-	if (status & IE_RENDERABLE_STATE_IN_VRAM) {
-		_update(*this, linkedRenderEngine->camera, (float) glfwGetTime(), renderCommandBufferIndex);
-	}
+    if (status & IE_RENDERABLE_STATE_IN_VRAM)
+        _update(*this, linkedRenderEngine->camera, (float) glfwGetTime(), renderCommandBufferIndex);
 }
 
 void IERenderable::_openglUpdate(const IECamera &camera, float time, uint32_t renderCommandBufferIndex) {
-	for (auto & associatedAsset : associatedAssets) {
-		IEAsset thisAsset = *associatedAsset.lock();
-		glm::quat quaternion = glm::yawPitchRoll(thisAsset.rotation.x, thisAsset.rotation.y, thisAsset.rotation.z);
-		modelMatrix = glm::rotate(glm::translate(glm::scale(glm::identity<glm::mat4>(), thisAsset.scale), thisAsset.position), glm::angle(quaternion), glm::axis(quaternion));
-		uniformBufferObject.projectionViewModelMatrix = camera.projectionMatrix * camera.viewMatrix;
-		uniformBufferObject.modelMatrix = modelMatrix;
-		uniformBufferObject.normalMatrix = glm::mat4(glm::transpose(glm::inverse(modelMatrix)));
-		uniformBufferObject.position = camera.position;
-		uniformBufferObject.time = time;
-//		modelBuffer.uploadToVRAM(&uniformBufferObject, sizeof(uniformBufferObject));
-		for (IEMesh &mesh: meshes) {
-			// Update uniforms
-			uniformBufferObject.openglUploadUniform((GLint) mesh.pipeline->programID);
-			mesh.update(renderCommandBufferIndex);
-		}
-	}
+    for (auto &associatedAsset : associatedAssets) {
+        IEAsset   thisAsset  = *associatedAsset.lock();
+        glm::quat quaternion = glm::yawPitchRoll(thisAsset.rotation.x, thisAsset.rotation.y, thisAsset.rotation.z);
+        modelMatrix          = glm::rotate(
+          glm::translate(glm::scale(glm::identity<glm::mat4>(), thisAsset.scale), thisAsset.position),
+          glm::angle(quaternion),
+          glm::axis(quaternion)
+        );
+        uniformBufferObject.projectionViewModelMatrix = camera.projectionMatrix * camera.viewMatrix;
+        uniformBufferObject.modelMatrix               = modelMatrix;
+        uniformBufferObject.normalMatrix              = glm::mat4(glm::transpose(glm::inverse(modelMatrix)));
+        uniformBufferObject.position                  = camera.position;
+        uniformBufferObject.time                      = time;
+        //		modelBuffer.uploadToVRAM(&uniformBufferObject, sizeof(uniformBufferObject));
+        for (IEMesh &mesh : meshes) {
+            // Update uniforms
+            uniformBufferObject.openglUploadUniform((GLint) mesh.pipeline->programID);
+            mesh.update(renderCommandBufferIndex);
+        }
+    }
 }
 
 void IERenderable::_vulkanUpdate(const IECamera &camera, float time, uint32_t renderCommandBufferIndex) {
-	for (auto & associatedAsset : associatedAssets) {
-		IEAsset thisAsset = *associatedAsset.lock();
-		glm::quat quaternion = glm::yawPitchRoll(thisAsset.rotation.x, thisAsset.rotation.y, thisAsset.rotation.z);
-		modelMatrix = glm::rotate(glm::translate(glm::scale(glm::identity<glm::mat4>(), thisAsset.scale), thisAsset.position), glm::angle(quaternion), glm::axis(quaternion));
-		uniformBufferObject.projectionViewModelMatrix = camera.projectionMatrix * camera.viewMatrix;
-		uniformBufferObject.modelMatrix = modelMatrix;
-		uniformBufferObject.normalMatrix = glm::mat4(glm::transpose(glm::inverse(modelMatrix)));
-		uniformBufferObject.position = camera.position;
-		uniformBufferObject.time = time;
-		modelBuffer.uploadToVRAM(&uniformBufferObject, sizeof(uniformBufferObject));
-		for (IEMesh &mesh: meshes) {
-			mesh.descriptorSet->update({&modelBuffer}, {0});
-			mesh.update(renderCommandBufferIndex);
-		}
-	}
+    for (auto &associatedAsset : associatedAssets) {
+        IEAsset   thisAsset  = *associatedAsset.lock();
+        glm::quat quaternion = glm::yawPitchRoll(thisAsset.rotation.x, thisAsset.rotation.y, thisAsset.rotation.z);
+        modelMatrix          = glm::rotate(
+          glm::translate(glm::scale(glm::identity<glm::mat4>(), thisAsset.scale), thisAsset.position),
+          glm::angle(quaternion),
+          glm::axis(quaternion)
+        );
+        uniformBufferObject.projectionViewModelMatrix = camera.projectionMatrix * camera.viewMatrix;
+        uniformBufferObject.modelMatrix               = modelMatrix;
+        uniformBufferObject.normalMatrix              = glm::mat4(glm::transpose(glm::inverse(modelMatrix)));
+        uniformBufferObject.position                  = camera.position;
+        uniformBufferObject.time                      = time;
+        modelBuffer.uploadToVRAM(&uniformBufferObject, sizeof(uniformBufferObject));
+        for (IEMesh &mesh : meshes) {
+            mesh.descriptorSet->update({&modelBuffer}, {0});
+            mesh.update(renderCommandBufferIndex);
+        }
+    }
 }
-
 
 std::function<void(IERenderable &)> IERenderable::_unloadFromVRAM{nullptr};
 
 void IERenderable::unloadFromVRAM() {
-	if (status & IE_RENDERABLE_STATE_IN_VRAM) {
-		_unloadFromVRAM(*this);
-	}
+    if (status & IE_RENDERABLE_STATE_IN_VRAM) _unloadFromVRAM(*this);
 }
 
 void IERenderable::_openglUnloadFromVRAM() {
-	for (IEMesh &mesh: meshes) {
-		mesh.unloadFromVRAM();
-	}
-	modelBuffer.unloadFromVRAM();
+    for (IEMesh &mesh : meshes) mesh.unloadFromVRAM();
+    modelBuffer.unloadFromVRAM();
 }
 
 void IERenderable::_vulkanUnloadFromVRAM() {
-	for (IEMesh &mesh: meshes) {
-		mesh.unloadFromVRAM();
-	}
-	modelBuffer.unloadFromVRAM();
+    for (IEMesh &mesh : meshes) mesh.unloadFromVRAM();
+    modelBuffer.unloadFromVRAM();
 }
-
 
 std::function<void(IERenderable &)> IERenderable::_unloadFromRAM{nullptr};
 
 void IERenderable::unloadFromRAM() {
-	if (status & IE_RENDERABLE_STATE_IN_RAM) {
-		_unloadFromRAM(*this);
-	}
+    if (status & IE_RENDERABLE_STATE_IN_RAM) _unloadFromRAM(*this);
 }
 
 void IERenderable::_openglUnloadFromRAM() {
-	for (IEMesh &mesh: meshes) {
-		mesh.unloadFromRAM();
-	}
+    for (IEMesh &mesh : meshes) mesh.unloadFromRAM();
 }
 
 void IERenderable::_vulkanUnloadFromRAM() {
-	for (IEMesh &mesh: meshes) {
-		mesh.unloadFromRAM();
-	}
+    for (IEMesh &mesh : meshes) mesh.unloadFromRAM();
 }

--- a/src/GraphicsModule/Renderable/IERenderable.hpp
+++ b/src/GraphicsModule/Renderable/IERenderable.hpp
@@ -8,108 +8,106 @@ class IECamera;
 /* Include classes used as attributes or function arguments. */
 // Internal dependencies
 #include "Buffer/IEBuffer.hpp"
-#include "Image/IETexture.hpp"
 #include "GraphicsModule/Shader/IEDescriptorSet.hpp"
-#include "IEMaterial.hpp"
 #include "GraphicsModule/Shader/IEPipeline.hpp"
 #include "GraphicsModule/Shader/IEShader.hpp"
 #include "GraphicsModule/Shader/IEUniformBufferObject.hpp"
+#include "IEMaterial.hpp"
 #include "IEVertex.hpp"
+#include "Image/IETexture.hpp"
 
 // Modular dependencies
 #include "Core/AssetModule/IEAspect.hpp"
 #include "IEMesh.hpp"
 
 // External dependencies
-#include <assimp/Importer.hpp>
 #include <assimp/BaseImporter.h>
-
+#include <assimp/Importer.hpp>
 #include <vulkan/vulkan.h>
 
 // System dependencies
-#include <string>
 #include <functional>
-
+#include <string>
 
 enum IERenderableStatus {
-	IE_RENDERABLE_STATE_UNKNOWN = 0x0,
-	IE_RENDERABLE_STATE_UNLOADED = 0x1,
-	IE_RENDERABLE_STATE_IN_RAM = 0x2,
-	IE_RENDERABLE_STATE_IN_VRAM = 0x4
+    IE_RENDERABLE_STATE_UNKNOWN  = 0x0,
+    IE_RENDERABLE_STATE_UNLOADED = 0x1,
+    IE_RENDERABLE_STATE_IN_RAM   = 0x2,
+    IE_RENDERABLE_STATE_IN_VRAM  = 0x4
 };
 
 class IERenderable : public IEAspect {
 public:
-	std::string modelName{};
-	std::vector<IEMesh> meshes{};
-	IEBuffer modelBuffer{};
-	IERenderEngine *linkedRenderEngine{};
-	IEUniformBufferObject uniformBufferObject{};
-	std::vector<IEShader> shaders{};
-	Assimp::Importer importer{};
-	bool render{true};
-	uint32_t commandBufferIndex{};
-	std::string directory{};
-	glm::mat4 modelMatrix{};
-	IERenderableStatus status{IE_RENDERABLE_STATE_UNKNOWN};
+    std::string           modelName{};
+    std::vector<IEMesh>   meshes{};
+    IEBuffer              modelBuffer{};
+    IERenderEngine       *linkedRenderEngine{};
+    IEUniformBufferObject uniformBufferObject{};
+    std::vector<IEShader> shaders{};
+    Assimp::Importer      importer{};
+    bool                  render{true};
+    uint32_t              commandBufferIndex{};
+    std::string           directory{};
+    glm::mat4             modelMatrix{};
+    IERenderableStatus    status{IE_RENDERABLE_STATE_UNKNOWN};
 
-	IERenderable() = default;
+    IERenderable() = default;
 
-	IERenderable(IERenderEngine *, const std::string &);
+    IERenderable(IERenderEngine *, const std::string &);
 
-	static void setAPI(const IEAPI &);
+    static void setAPI(const IEAPI &);
 
-	/* API dependent functions */
-	static std::function<void(IERenderable &, IERenderEngine *, const std::string &)> _create;
+    /* API dependent functions */
+    static std::function<void(IERenderable &, IERenderEngine *, const std::string &)> _create;
 
-	void create(IERenderEngine *, const std::string &);
+    void create(IERenderEngine *, const std::string &);
 
-	void _openglCreate(IERenderEngine *, const std::string &);
+    void _openglCreate(IERenderEngine *, const std::string &);
 
-	void _vulkanCreate(IERenderEngine *, const std::string &);
-
-
-	static std::function<void(IERenderable &)> _loadFromDiskToRAM;
-
-	void loadFromDiskToRAM();
-
-	void _openglLoadFromDiskToRAM();
-
-	void _vulkanLoadFromDiskToRAM();
+    void _vulkanCreate(IERenderEngine *, const std::string &);
 
 
-	static std::function<void(IERenderable &)> _loadFromRAMToVRAM;
+    static std::function<void(IERenderable &)> _loadFromDiskToRAM;
 
-	void loadFromRAMToVRAM();
+    void loadFromDiskToRAM();
 
-	void _openglLoadFromRAMToVRAM();
+    void _openglLoadFromDiskToRAM();
 
-	void _vulkanLoadFromRAMToVRAM();
-
-
-	static std::function<void(IERenderable &, const IECamera &, float, uint32_t)> _update;
-
-	void update(uint32_t);
-
-	void _openglUpdate(const IECamera &camera, float time, uint32_t renderCommandBufferIndex);
-
-	void _vulkanUpdate(const IECamera &camera, float time, uint32_t renderCommandBufferIndex);
+    void _vulkanLoadFromDiskToRAM();
 
 
-	static std::function<void(IERenderable &)> _unloadFromVRAM;
+    static std::function<void(IERenderable &)> _loadFromRAMToVRAM;
 
-	void unloadFromVRAM();
+    void loadFromRAMToVRAM();
 
-	void _openglUnloadFromVRAM();
+    void _openglLoadFromRAMToVRAM();
 
-	void _vulkanUnloadFromVRAM();
+    void _vulkanLoadFromRAMToVRAM();
 
 
-	static std::function<void(IERenderable &)> _unloadFromRAM;
+    static std::function<void(IERenderable &, const IECamera &, float, uint32_t)> _update;
 
-	void unloadFromRAM();
+    void update(uint32_t);
 
-	void _openglUnloadFromRAM();
+    void _openglUpdate(const IECamera &camera, float time, uint32_t renderCommandBufferIndex);
 
-	void _vulkanUnloadFromRAM();
+    void _vulkanUpdate(const IECamera &camera, float time, uint32_t renderCommandBufferIndex);
+
+
+    static std::function<void(IERenderable &)> _unloadFromVRAM;
+
+    void unloadFromVRAM();
+
+    void _openglUnloadFromVRAM();
+
+    void _vulkanUnloadFromVRAM();
+
+
+    static std::function<void(IERenderable &)> _unloadFromRAM;
+
+    void unloadFromRAM();
+
+    void _openglUnloadFromRAM();
+
+    void _vulkanUnloadFromRAM();
 };

--- a/src/GraphicsModule/Renderable/IEVertex.cpp
+++ b/src/GraphicsModule/Renderable/IEVertex.cpp
@@ -2,93 +2,125 @@
 #include "IEVertex.hpp"
 
 /* Include external dependencies. */
-#include <vulkan/vulkan.h>
 #include <string>
+#include <vulkan/vulkan.h>
 
 VkVertexInputBindingDescription IEVertex::getBindingDescription() {
-	return {
-			.binding=0,
-			.stride=sizeof(IEVertex),
-			.inputRate=VK_VERTEX_INPUT_RATE_VERTEX
-	};
+    return {.binding = 0, .stride = sizeof(IEVertex), .inputRate = VK_VERTEX_INPUT_RATE_VERTEX};
 }
 
 std::array<VkVertexInputAttributeDescription, 6> IEVertex::getAttributeDescriptions() {
-	return {
-			{
-					{
-							.location = 0,
-							.binding = 0,
-							.format = VK_FORMAT_R32G32B32_SFLOAT,
-							.offset = offsetof(IEVertex, position),
-					},
-					{
-							.location = 1,
-							.binding = 0,
-							.format = VK_FORMAT_R32G32B32_SFLOAT,
-							.offset = offsetof(IEVertex, color),
-					},
-					{
-							.location = 2,
-							.binding = 0,
-							.format = VK_FORMAT_R32G32_SFLOAT,
-							.offset = offsetof(IEVertex, textureCoordinates),
-					},
-					{
-							.location = 3,
-							.binding = 0,
-							.format = VK_FORMAT_R32G32B32_SFLOAT,
-							.offset = offsetof(IEVertex, normal),
-					},
-					{
-							.location = 4,
-							.binding = 0,
-							.format = VK_FORMAT_R32G32B32_SFLOAT,
-							.offset = offsetof(IEVertex, tangent),
-					},
-					{
-							.location = 5,
-							.binding = 0,
-							.format = VK_FORMAT_R32G32B32_SFLOAT,
-							.offset = offsetof(IEVertex, biTangent),
-					}
-			}
-	};
+    return {
+      {{
+         .location = 0,
+         .binding  = 0,
+         .format   = VK_FORMAT_R32G32B32_SFLOAT,
+         .offset   = offsetof(IEVertex, position),
+       }, {
+         .location = 1,
+         .binding  = 0,
+         .format   = VK_FORMAT_R32G32B32_SFLOAT,
+         .offset   = offsetof(IEVertex, color),
+       }, {
+         .location = 2,
+         .binding  = 0,
+         .format   = VK_FORMAT_R32G32_SFLOAT,
+         .offset   = offsetof(IEVertex, textureCoordinates),
+       }, {
+         .location = 3,
+         .binding  = 0,
+         .format   = VK_FORMAT_R32G32B32_SFLOAT,
+         .offset   = offsetof(IEVertex, normal),
+       }, {
+         .location = 4,
+         .binding  = 0,
+         .format   = VK_FORMAT_R32G32B32_SFLOAT,
+         .offset   = offsetof(IEVertex, tangent),
+       }, {
+         .location = 5,
+         .binding  = 0,
+         .format   = VK_FORMAT_R32G32B32_SFLOAT,
+         .offset   = offsetof(IEVertex, biTangent),
+       }}
+    };
 }
 
 void IEVertex::useVertexAttributesWithProgram(GLint program) {
-	int attributeLocation = glGetAttribLocation(program, "vertexPosition");
-	if (attributeLocation >= 0) {
-		glEnableVertexAttribArray(attributeLocation);
-		glVertexAttribPointer(attributeLocation, 3, GL_FLOAT, GL_FALSE, sizeof(IEVertex), (void *) offsetof(IEVertex, position));
-	}
-	attributeLocation = glGetAttribLocation(program, "vertexColor");
-	if (attributeLocation >= 0) {
-		glEnableVertexAttribArray(attributeLocation);
-		glVertexAttribPointer(attributeLocation, 4, GL_FLOAT, GL_FALSE, sizeof(IEVertex), (void *) offsetof(IEVertex, color));
-	}
-	attributeLocation = glGetAttribLocation(program, "vertexTextureCoordinates");
-	if (attributeLocation >= 0) {
-		glEnableVertexAttribArray(attributeLocation);
-		glVertexAttribPointer(attributeLocation, 2, GL_FLOAT, GL_FALSE, sizeof(IEVertex), (void *) offsetof(IEVertex, textureCoordinates));
-	}
-	attributeLocation = glGetAttribLocation(program, "vertexNormal");
-	if (attributeLocation >= 0) {
-		glEnableVertexAttribArray(attributeLocation);
-		glVertexAttribPointer(attributeLocation, 3, GL_FLOAT, GL_FALSE, sizeof(IEVertex), (void *) offsetof(IEVertex, normal));
-	}
-	attributeLocation = glGetAttribLocation(program, "vertexTangent");
-	if (attributeLocation >= 0) {
-		glEnableVertexAttribArray(attributeLocation);
-		glVertexAttribPointer(attributeLocation, 3, GL_FLOAT, GL_FALSE, sizeof(IEVertex), (void *) offsetof(IEVertex, tangent));
-	}
-	attributeLocation = glGetAttribLocation(program, "vertexBiTangent");
-	if (attributeLocation >= 0) {
-		glEnableVertexAttribArray(attributeLocation);
-		glVertexAttribPointer(attributeLocation, 3, GL_FLOAT, GL_FALSE, sizeof(IEVertex), (void *) offsetof(IEVertex, biTangent));
-	}
+    int attributeLocation = glGetAttribLocation(program, "vertexPosition");
+    if (attributeLocation >= 0) {
+        glEnableVertexAttribArray(attributeLocation);
+        glVertexAttribPointer(
+          attributeLocation,
+          3,
+          GL_FLOAT,
+          GL_FALSE,
+          sizeof(IEVertex),
+          (void *) offsetof(IEVertex, position)
+        );
+    }
+    attributeLocation = glGetAttribLocation(program, "vertexColor");
+    if (attributeLocation >= 0) {
+        glEnableVertexAttribArray(attributeLocation);
+        glVertexAttribPointer(
+          attributeLocation,
+          4,
+          GL_FLOAT,
+          GL_FALSE,
+          sizeof(IEVertex),
+          (void *) offsetof(IEVertex, color)
+        );
+    }
+    attributeLocation = glGetAttribLocation(program, "vertexTextureCoordinates");
+    if (attributeLocation >= 0) {
+        glEnableVertexAttribArray(attributeLocation);
+        glVertexAttribPointer(
+          attributeLocation,
+          2,
+          GL_FLOAT,
+          GL_FALSE,
+          sizeof(IEVertex),
+          (void *) offsetof(IEVertex, textureCoordinates)
+        );
+    }
+    attributeLocation = glGetAttribLocation(program, "vertexNormal");
+    if (attributeLocation >= 0) {
+        glEnableVertexAttribArray(attributeLocation);
+        glVertexAttribPointer(
+          attributeLocation,
+          3,
+          GL_FLOAT,
+          GL_FALSE,
+          sizeof(IEVertex),
+          (void *) offsetof(IEVertex, normal)
+        );
+    }
+    attributeLocation = glGetAttribLocation(program, "vertexTangent");
+    if (attributeLocation >= 0) {
+        glEnableVertexAttribArray(attributeLocation);
+        glVertexAttribPointer(
+          attributeLocation,
+          3,
+          GL_FLOAT,
+          GL_FALSE,
+          sizeof(IEVertex),
+          (void *) offsetof(IEVertex, tangent)
+        );
+    }
+    attributeLocation = glGetAttribLocation(program, "vertexBiTangent");
+    if (attributeLocation >= 0) {
+        glEnableVertexAttribArray(attributeLocation);
+        glVertexAttribPointer(
+          attributeLocation,
+          3,
+          GL_FLOAT,
+          GL_FALSE,
+          sizeof(IEVertex),
+          (void *) offsetof(IEVertex, biTangent)
+        );
+    }
 }
 
 bool IEVertex::operator==(IEVertex &other) const {
-	return position == other.position && color == other.color && textureCoordinates == other.textureCoordinates && normal == other.normal && tangent == other.tangent && biTangent == other.biTangent;
+    return position == other.position && color == other.color && textureCoordinates == other.textureCoordinates &&
+      normal == other.normal && tangent == other.tangent && biTangent == other.biTangent;
 }

--- a/src/GraphicsModule/Renderable/IEVertex.hpp
+++ b/src/GraphicsModule/Renderable/IEVertex.hpp
@@ -9,9 +9,11 @@ struct VkVertexInputAttributeDescription;
 // External dependencies
 
 #define GLM_FORCE_RADIANS
+
 #include <glm/glm.hpp>
 
 #define GLEW_IMPLEMENTATION
+
 #include <include/GL/glew.h>
 
 // System dependencies
@@ -19,18 +21,18 @@ struct VkVertexInputAttributeDescription;
 #include <string>
 
 struct IEVertex {
-	glm::vec3 position{};
-	glm::vec4 color{};
-	glm::vec2 textureCoordinates{};
-	glm::vec3 normal{};
-	glm::vec3 tangent{};
-	glm::vec3 biTangent{};
+    glm::vec3 position{};
+    glm::vec4 color{};
+    glm::vec2 textureCoordinates{};
+    glm::vec3 normal{};
+    glm::vec3 tangent{};
+    glm::vec3 biTangent{};
 
-	static VkVertexInputBindingDescription getBindingDescription();
+    static VkVertexInputBindingDescription getBindingDescription();
 
-	static std::array<VkVertexInputAttributeDescription, 6> getAttributeDescriptions();
-	
-	static void useVertexAttributesWithProgram(GLint program);
+    static std::array<VkVertexInputAttributeDescription, 6> getAttributeDescriptions();
 
-	bool operator==(IEVertex &other) const;
+    static void useVertexAttributesWithProgram(GLint program);
+
+    bool operator==(IEVertex &other) const;
 };

--- a/src/GraphicsModule/Shader/IEDescriptorSet.cpp
+++ b/src/GraphicsModule/Shader/IEDescriptorSet.cpp
@@ -3,154 +3,171 @@
 
 /* Include dependencies within this module. */
 #include "GraphicsModule/Buffer/IEBuffer.hpp"
-#include "IERenderEngine.hpp"
-
 #include "GraphicsModule/Image/IEImage.hpp"
+#include "IERenderEngine.hpp"
 
 /* Include system dependencies. */
 #include <cassert>
 
-
 void IEDescriptorSet::destroy() {
-	for (const std::function<void()> &function: deletionQueue) { function(); }
-	deletionQueue.clear();
+    for (const std::function<void()> &function : deletionQueue) function();
+    deletionQueue.clear();
 }
 
 void IEDescriptorSet::create(IERenderEngine *renderEngineLink, IEDescriptorSet::CreateInfo *createInfo) {
-	linkedRenderEngine = renderEngineLink;
-	createdWith = *createInfo;
-	assert(!createdWith.data.empty());
-	assert(createdWith.data.size() == createdWith.shaderStages.size() && createdWith.data.size() == createdWith.poolSizes.size());
-	std::vector<VkDescriptorSetLayoutBinding> descriptorSetLayoutBindings{};
-	descriptorSetLayoutBindings.reserve(createdWith.poolSizes.size());
-	for (unsigned long i = 0; i < createdWith.poolSizes.size(); ++i) {
-		VkDescriptorSetLayoutBinding descriptorSetLayoutBinding{};
-		descriptorSetLayoutBinding.descriptorType = createdWith.poolSizes[i].type;
-		descriptorSetLayoutBinding.binding = i;
-		descriptorSetLayoutBinding.stageFlags = createdWith.shaderStages[i];
-		descriptorSetLayoutBinding.descriptorCount = createdWith.poolSizes[i].descriptorCount;
-		descriptorSetLayoutBindings.push_back(descriptorSetLayoutBinding);
-	}
-	std::vector<VkDescriptorBindingFlagsEXT> flags{};
-	flags.resize(createdWith.data.size());
-	flags[flags.size() - 1] = createdWith.flags;
-	VkDescriptorSetLayoutBindingFlagsCreateInfoEXT descriptorSetLayoutBindingFlagsCreateInfo{
-			VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
-	descriptorSetLayoutBindingFlagsCreateInfo.bindingCount = static_cast<uint32_t>(descriptorSetLayoutBindings.size());
-	descriptorSetLayoutBindingFlagsCreateInfo.pBindingFlags = flags.data();
-	VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-	if (linkedRenderEngine->extensionAndFeatureInfo.queryFeatureSupport(IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT)) {
-		descriptorSetLayoutCreateInfo.pNext = &descriptorSetLayoutBindingFlagsCreateInfo;
-	}
-	descriptorSetLayoutCreateInfo.pBindings = descriptorSetLayoutBindings.data();
-	descriptorSetLayoutCreateInfo.bindingCount = static_cast<uint32_t>(descriptorSetLayoutBindings.size());
-	if (vkCreateDescriptorSetLayout(linkedRenderEngine->device.device, &descriptorSetLayoutCreateInfo, nullptr, &descriptorSetLayout) !=
-		VK_SUCCESS) { throw std::runtime_error("failed to create descriptor layout!"); }
-	deletionQueue.emplace_back([&] { vkDestroyDescriptorSetLayout(linkedRenderEngine->device.device, descriptorSetLayout, nullptr); });
-	VkDescriptorPoolCreateInfo descriptorPoolCreateInfo{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
-	descriptorPoolCreateInfo.poolSizeCount = static_cast<uint32_t>(createdWith.poolSizes.size());
-	descriptorPoolCreateInfo.pPoolSizes = createdWith.poolSizes.data();
-	descriptorPoolCreateInfo.maxSets = 1;
-	if (vkCreateDescriptorPool(linkedRenderEngine->device.device, &descriptorPoolCreateInfo, nullptr, &descriptorPool) !=
-		VK_SUCCESS) { throw std::runtime_error("failed to create descriptor pool!"); }
-	deletionQueue.emplace_back([&] {
-		vkDestroyDescriptorPool(linkedRenderEngine->device.device, descriptorPool, nullptr);
-	});
-	VkDescriptorSetVariableDescriptorCountAllocateInfoEXT descriptorSetVariableDescriptorCountAllocateInfo{
-			VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT};
-	descriptorSetVariableDescriptorCountAllocateInfo.descriptorSetCount = 1;
-	descriptorSetVariableDescriptorCountAllocateInfo.pDescriptorCounts = &createdWith.maxIndex;
-	VkDescriptorSetAllocateInfo descriptorSetAllocateInfo{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
-	if (linkedRenderEngine->extensionAndFeatureInfo.queryFeatureSupport(IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT)) {
-		descriptorSetAllocateInfo.pNext = &descriptorSetVariableDescriptorCountAllocateInfo;
-	}
-	descriptorSetAllocateInfo.descriptorPool = descriptorPool;
-	descriptorSetAllocateInfo.pSetLayouts = &descriptorSetLayout;
-	descriptorSetAllocateInfo.descriptorSetCount = 1;
-	if (vkAllocateDescriptorSets(linkedRenderEngine->device.device, &descriptorSetAllocateInfo, &descriptorSet) !=
-		VK_SUCCESS) { throw std::runtime_error("failed to allocate descriptor set!"); }
-	std::vector<int> bindings{};
-	bindings.reserve(createdWith.data.size());
-	std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> data{};
-	data.reserve(createdWith.data.size());
-	for (size_t i = 0; i < createdWith.data.size(); ++i) {
-		if (createdWith.data[i].has_value()) {
-			bindings.push_back(i);
-			data.push_back(createdWith.data[i]);
-		}
-	}
-	update(data, bindings);
+    linkedRenderEngine = renderEngineLink;
+    createdWith        = *createInfo;
+    assert(!createdWith.data.empty());
+    assert(
+      createdWith.data.size() == createdWith.shaderStages.size() &&
+      createdWith.data.size() == createdWith.poolSizes.size()
+    );
+    std::vector<VkDescriptorSetLayoutBinding> descriptorSetLayoutBindings{};
+    descriptorSetLayoutBindings.reserve(createdWith.poolSizes.size());
+    for (unsigned long i = 0; i < createdWith.poolSizes.size(); ++i) {
+        VkDescriptorSetLayoutBinding descriptorSetLayoutBinding{};
+        descriptorSetLayoutBinding.descriptorType  = createdWith.poolSizes[i].type;
+        descriptorSetLayoutBinding.binding         = i;
+        descriptorSetLayoutBinding.stageFlags      = createdWith.shaderStages[i];
+        descriptorSetLayoutBinding.descriptorCount = createdWith.poolSizes[i].descriptorCount;
+        descriptorSetLayoutBindings.push_back(descriptorSetLayoutBinding);
+    }
+    std::vector<VkDescriptorBindingFlagsEXT> flags{};
+    flags.resize(createdWith.data.size());
+    flags[flags.size() - 1] = createdWith.flags;
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT descriptorSetLayoutBindingFlagsCreateInfo{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
+    descriptorSetLayoutBindingFlagsCreateInfo.bindingCount =
+      static_cast<uint32_t>(descriptorSetLayoutBindings.size());
+    descriptorSetLayoutBindingFlagsCreateInfo.pBindingFlags = flags.data();
+    VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+    if (linkedRenderEngine->extensionAndFeatureInfo.queryFeatureSupport(
+          IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT
+        )) {
+        descriptorSetLayoutCreateInfo.pNext = &descriptorSetLayoutBindingFlagsCreateInfo;
+    }
+    descriptorSetLayoutCreateInfo.pBindings    = descriptorSetLayoutBindings.data();
+    descriptorSetLayoutCreateInfo.bindingCount = static_cast<uint32_t>(descriptorSetLayoutBindings.size());
+    if (vkCreateDescriptorSetLayout(linkedRenderEngine->device.device, &descriptorSetLayoutCreateInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create descriptor layout!");
+    }
+    deletionQueue.emplace_back([&] {
+        vkDestroyDescriptorSetLayout(linkedRenderEngine->device.device, descriptorSetLayout, nullptr);
+    });
+    VkDescriptorPoolCreateInfo descriptorPoolCreateInfo{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+    descriptorPoolCreateInfo.poolSizeCount = static_cast<uint32_t>(createdWith.poolSizes.size());
+    descriptorPoolCreateInfo.pPoolSizes    = createdWith.poolSizes.data();
+    descriptorPoolCreateInfo.maxSets       = 1;
+    if (vkCreateDescriptorPool(linkedRenderEngine->device.device, &descriptorPoolCreateInfo, nullptr, &descriptorPool) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create descriptor pool!");
+    }
+    deletionQueue.emplace_back([&] {
+        vkDestroyDescriptorPool(linkedRenderEngine->device.device, descriptorPool, nullptr);
+    });
+    VkDescriptorSetVariableDescriptorCountAllocateInfoEXT descriptorSetVariableDescriptorCountAllocateInfo{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT};
+    descriptorSetVariableDescriptorCountAllocateInfo.descriptorSetCount = 1;
+    descriptorSetVariableDescriptorCountAllocateInfo.pDescriptorCounts  = &createdWith.maxIndex;
+    VkDescriptorSetAllocateInfo descriptorSetAllocateInfo{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+    if (linkedRenderEngine->extensionAndFeatureInfo.queryFeatureSupport(
+          IE_ENGINE_FEATURE_QUERY_VARIABLE_DESCRIPTOR_COUNT
+        )) {
+        descriptorSetAllocateInfo.pNext = &descriptorSetVariableDescriptorCountAllocateInfo;
+    }
+    descriptorSetAllocateInfo.descriptorPool     = descriptorPool;
+    descriptorSetAllocateInfo.pSetLayouts        = &descriptorSetLayout;
+    descriptorSetAllocateInfo.descriptorSetCount = 1;
+    if (vkAllocateDescriptorSets(linkedRenderEngine->device.device, &descriptorSetAllocateInfo, &descriptorSet) != VK_SUCCESS) {
+        throw std::runtime_error("failed to allocate descriptor set!");
+    }
+    std::vector<int> bindings{};
+    bindings.reserve(createdWith.data.size());
+    std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> data{};
+    data.reserve(createdWith.data.size());
+    for (size_t i = 0; i < createdWith.data.size(); ++i) {
+        if (createdWith.data[i].has_value()) {
+            bindings.push_back(i);
+            data.push_back(createdWith.data[i]);
+        }
+    }
+    update(data, bindings);
 }
 
-void IEDescriptorSet::update(std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> newData,
-							 std::vector<int> bindings) {
-	std::vector<VkDescriptorImageInfo> imageDescriptorInfos{};
-	imageDescriptorInfos.reserve(createdWith.poolSizes.size());
-	std::vector<VkDescriptorBufferInfo> bufferDescriptorInfos{};
-	bufferDescriptorInfos.reserve(createdWith.poolSizes.size());
-	if (bindings.empty()) {
-		bindings.resize(newData.size(), 0);
-	}
-	std::vector<VkWriteDescriptorSet> descriptorWrites{};
-	descriptorWrites.resize(bindings.size());
-	for (unsigned long i = 0; i < bindings.size(); ++i) {
-		if (newData[i].has_value()) {
-			VkWriteDescriptorSet writeDescriptorSet{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
-			writeDescriptorSet.dstSet = descriptorSet;
-			writeDescriptorSet.descriptorType = createdWith.poolSizes[bindings[i]].type;
-			writeDescriptorSet.dstBinding = bindings[i];
-			writeDescriptorSet.descriptorCount = writeDescriptorSet.dstBinding == createdWith.data.size() ? createdWith.maxIndex : 1;
-			if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
-				VkDescriptorImageInfo storageImageDescriptorInfo{};
-				storageImageDescriptorInfo.imageView = std::get<IEImage *>(newData[i].value())->view;
-				storageImageDescriptorInfo.sampler = std::get<IEImage *>(newData[i].value())->sampler;
-				storageImageDescriptorInfo.imageLayout = std::get<IEImage *>(newData[i].value())->layout;
-				if (storageImageDescriptorInfo.imageView == VK_NULL_HANDLE) {
-					throw std::runtime_error("no image given or given image does not have an associated view!");
-				}
-				imageDescriptorInfos.push_back(storageImageDescriptorInfo);
-				writeDescriptorSet.pImageInfo = &imageDescriptorInfos[imageDescriptorInfos.size() - 1];
-			} else if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
-				VkDescriptorImageInfo combinedImageSamplerDescriptorInfo{};
-				combinedImageSamplerDescriptorInfo.imageView = std::get<IEImage *>(newData[i].value())->view;
-				combinedImageSamplerDescriptorInfo.sampler = std::get<IEImage *>(newData[i].value())->sampler;
-				combinedImageSamplerDescriptorInfo.imageLayout = std::get<IEImage *>(newData[i].value())->layout;
-				if (combinedImageSamplerDescriptorInfo.sampler == VK_NULL_HANDLE) {
-					throw std::runtime_error("no image given or given image does not have an associated sampler!");
-				}
-				imageDescriptorInfos.push_back(combinedImageSamplerDescriptorInfo);
-				writeDescriptorSet.pImageInfo = &imageDescriptorInfos[imageDescriptorInfos.size() - 1];
-			} else if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
-				VkDescriptorBufferInfo storageBufferDescriptorInfo{};
-				storageBufferDescriptorInfo.buffer = std::get<IEBuffer *>(newData[i].value())->buffer;
-				storageBufferDescriptorInfo.offset = 0;
-				storageBufferDescriptorInfo.range = VK_WHOLE_SIZE;
-				if (storageBufferDescriptorInfo.buffer == VK_NULL_HANDLE) {
-					throw std::runtime_error("no IEBuffer given or given IEBuffer has not been created!");
-				}
-				bufferDescriptorInfos.push_back(storageBufferDescriptorInfo);
-				writeDescriptorSet.pBufferInfo = &bufferDescriptorInfos[bufferDescriptorInfos.size() - 1];
-			} else if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
-				VkDescriptorBufferInfo uniformBufferDescriptorInfo{};
-				uniformBufferDescriptorInfo.buffer = std::get<IEBuffer *>(newData[i].value())->buffer;
-				uniformBufferDescriptorInfo.offset = 0;
-				uniformBufferDescriptorInfo.range = VK_WHOLE_SIZE;
-				if (uniformBufferDescriptorInfo.buffer == VK_NULL_HANDLE) {
-					throw std::runtime_error("no IEBuffer given or given IEBuffer has not been created!");
-				}
-				bufferDescriptorInfos.push_back(uniformBufferDescriptorInfo);
-				writeDescriptorSet.pBufferInfo = &bufferDescriptorInfos[bufferDescriptorInfos.size() - 1];
-			} else {
-				throw std::runtime_error("unsupported descriptor type: " + std::to_string(writeDescriptorSet.descriptorType));
-			}
-			descriptorWrites[i] = writeDescriptorSet;
-		}
-	}
-	if (!descriptorWrites.empty()) {
-		vkUpdateDescriptorSets(linkedRenderEngine->device.device, descriptorWrites.size(), descriptorWrites.data(), 0, nullptr);
-	}
+void IEDescriptorSet::update(
+  std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> newData,
+  std::vector<int>                                                bindings
+) {
+    std::vector<VkDescriptorImageInfo> imageDescriptorInfos{};
+    imageDescriptorInfos.reserve(createdWith.poolSizes.size());
+    std::vector<VkDescriptorBufferInfo> bufferDescriptorInfos{};
+    bufferDescriptorInfos.reserve(createdWith.poolSizes.size());
+    if (bindings.empty()) bindings.resize(newData.size(), 0);
+    std::vector<VkWriteDescriptorSet> descriptorWrites{};
+    descriptorWrites.resize(bindings.size());
+    for (unsigned long i = 0; i < bindings.size(); ++i) {
+        if (newData[i].has_value()) {
+            VkWriteDescriptorSet writeDescriptorSet{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+            writeDescriptorSet.dstSet         = descriptorSet;
+            writeDescriptorSet.descriptorType = createdWith.poolSizes[bindings[i]].type;
+            writeDescriptorSet.dstBinding     = bindings[i];
+            writeDescriptorSet.descriptorCount =
+              writeDescriptorSet.dstBinding == createdWith.data.size() ? createdWith.maxIndex : 1;
+            if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+                VkDescriptorImageInfo storageImageDescriptorInfo{};
+                storageImageDescriptorInfo.imageView   = std::get<IEImage *>(newData[i].value())->view;
+                storageImageDescriptorInfo.sampler     = std::get<IEImage *>(newData[i].value())->sampler;
+                storageImageDescriptorInfo.imageLayout = std::get<IEImage *>(newData[i].value())->layout;
+                if (storageImageDescriptorInfo.imageView == VK_NULL_HANDLE)
+                    throw std::runtime_error("no image given or given image does not have an associated view!");
+                imageDescriptorInfos.push_back(storageImageDescriptorInfo);
+                writeDescriptorSet.pImageInfo = &imageDescriptorInfos[imageDescriptorInfos.size() - 1];
+            } else if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+                VkDescriptorImageInfo combinedImageSamplerDescriptorInfo{};
+                combinedImageSamplerDescriptorInfo.imageView   = std::get<IEImage *>(newData[i].value())->view;
+                combinedImageSamplerDescriptorInfo.sampler     = std::get<IEImage *>(newData[i].value())->sampler;
+                combinedImageSamplerDescriptorInfo.imageLayout = std::get<IEImage *>(newData[i].value())->layout;
+                if (combinedImageSamplerDescriptorInfo.sampler == VK_NULL_HANDLE)
+                    throw std::runtime_error("no image given or given image does not have an associated sampler!");
+                imageDescriptorInfos.push_back(combinedImageSamplerDescriptorInfo);
+                writeDescriptorSet.pImageInfo = &imageDescriptorInfos[imageDescriptorInfos.size() - 1];
+            } else if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+                VkDescriptorBufferInfo storageBufferDescriptorInfo{};
+                storageBufferDescriptorInfo.buffer = std::get<IEBuffer *>(newData[i].value())->buffer;
+                storageBufferDescriptorInfo.offset = 0;
+                storageBufferDescriptorInfo.range  = VK_WHOLE_SIZE;
+                if (storageBufferDescriptorInfo.buffer == VK_NULL_HANDLE)
+                    throw std::runtime_error("no IEBuffer given or given IEBuffer has not been created!");
+                bufferDescriptorInfos.push_back(storageBufferDescriptorInfo);
+                writeDescriptorSet.pBufferInfo = &bufferDescriptorInfos[bufferDescriptorInfos.size() - 1];
+            } else if (writeDescriptorSet.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
+                VkDescriptorBufferInfo uniformBufferDescriptorInfo{};
+                uniformBufferDescriptorInfo.buffer = std::get<IEBuffer *>(newData[i].value())->buffer;
+                uniformBufferDescriptorInfo.offset = 0;
+                uniformBufferDescriptorInfo.range  = VK_WHOLE_SIZE;
+                if (uniformBufferDescriptorInfo.buffer == VK_NULL_HANDLE)
+                    throw std::runtime_error("no IEBuffer given or given IEBuffer has not been created!");
+                bufferDescriptorInfos.push_back(uniformBufferDescriptorInfo);
+                writeDescriptorSet.pBufferInfo = &bufferDescriptorInfos[bufferDescriptorInfos.size() - 1];
+            } else {
+                throw std::runtime_error(
+                  "unsupported descriptor type: " + std::to_string(writeDescriptorSet.descriptorType)
+                );
+            }
+            descriptorWrites[i] = writeDescriptorSet;
+        }
+    }
+    if (!descriptorWrites.empty()) {
+        vkUpdateDescriptorSets(
+          linkedRenderEngine->device.device,
+          descriptorWrites.size(),
+          descriptorWrites.data(),
+          0,
+          nullptr
+        );
+    }
 }
 
 IEDescriptorSet::~IEDescriptorSet() {
-	destroy();
+    destroy();
 }

--- a/src/GraphicsModule/Shader/IEDescriptorSet.hpp
+++ b/src/GraphicsModule/Shader/IEDescriptorSet.hpp
@@ -22,36 +22,38 @@ class IERenderEngine;
 #include <variant>
 #include <vector>
 
-
 class IEDescriptorSet : public IEDependency {
 public:
-	struct CreateInfo {
-		//Required
-		std::vector<VkDescriptorPoolSize> poolSizes{};
-		std::vector<VkShaderStageFlagBits> shaderStages{};
-		std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> data{};
+    struct CreateInfo {
+        // Required
+        std::vector<VkDescriptorPoolSize>                               poolSizes{};
+        std::vector<VkShaderStageFlagBits>                              shaderStages{};
+        std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> data{};
 
-		//Optional
-		uint32_t maxIndex{1};
+        // Optional
+        uint32_t maxIndex{1};
 
-		//Required if maxIndex != 1
-		VkDescriptorBindingFlagsEXT flags{0};
-	};
+        // Required if maxIndex != 1
+        VkDescriptorBindingFlagsEXT flags{0};
+    };
 
-	VkDescriptorPool descriptorPool{};
-	VkDescriptorSet descriptorSet{};
-	VkDescriptorSetLayout descriptorSetLayout{};
-	CreateInfo createdWith{};
+    VkDescriptorPool      descriptorPool{};
+    VkDescriptorSet       descriptorSet{};
+    VkDescriptorSetLayout descriptorSetLayout{};
+    CreateInfo            createdWith{};
 
-	void destroy();
+    void destroy();
 
-	void create(IERenderEngine *renderEngineLink, CreateInfo *createInfo);
+    void create(IERenderEngine *renderEngineLink, CreateInfo *createInfo);
 
-	void update(std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> newData, std::vector<int> bindings = {});
+    void update(
+      std::vector<std::optional<std::variant<IEImage *, IEBuffer *>>> newData,
+      std::vector<int>                                                bindings = {}
+    );
 
-	~IEDescriptorSet() override;
+    ~IEDescriptorSet() override;
 
 private:
-	IERenderEngine *linkedRenderEngine{};
-	std::vector<std::function<void()>> deletionQueue{};
+    IERenderEngine                    *linkedRenderEngine{};
+    std::vector<std::function<void()>> deletionQueue{};
 };

--- a/src/GraphicsModule/Shader/IEPipeline.cpp
+++ b/src/GraphicsModule/Shader/IEPipeline.cpp
@@ -2,205 +2,201 @@
 #include "IEPipeline.hpp"
 
 /* Include dependencies within this module. */
+#include "GraphicsModule/Renderable/IEVertex.hpp"
 #include "IEDescriptorSet.hpp"
 #include "IERenderEngine.hpp"
-#include "GraphicsModule/Renderable/IEVertex.hpp"
 
 /* Include dependencies from Core. */
 #include "Core/LogModule/IELogger.hpp"
 
 #include <memory>
 
-
 void IEPipeline::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_create = &IEPipeline::_openglCreate;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_create = &IEPipeline::_vulkanCreate;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) _create = &IEPipeline::_openglCreate;
+    else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) _create = &IEPipeline::_vulkanCreate;
 }
 
 void IEPipeline::destroy() {
-	for (const std::function<void()> &function: deletionQueue) {
-		function();
-	}
-	deletionQueue.clear();
+    for (const std::function<void()> &function : deletionQueue) function();
+    deletionQueue.clear();
 }
 
 std::function<void(IEPipeline &, IERenderEngine *, IEPipeline::CreateInfo *)> IEPipeline::_create = nullptr;
 
 void IEPipeline::create(IERenderEngine *engineLink, IEPipeline::CreateInfo *createInfo) {
-	linkedRenderEngine = engineLink;
-	_create(*this, engineLink, createInfo);
+    linkedRenderEngine = engineLink;
+    _create(*this, engineLink, createInfo);
 }
 
 void IEPipeline::_openglCreate(IERenderEngine *engineLink, IEPipeline::CreateInfo *createInfo) {
-	programID = glCreateProgram();
-	for (std::shared_ptr<IEShader> &shader: createInfo->shaders) {
-		glAttachShader(programID, shader->shaderID);
-	}
-	glLinkProgram(programID);
+    programID = glCreateProgram();
+    for (std::shared_ptr<IEShader> &shader : createInfo->shaders) glAttachShader(programID, shader->shaderID);
+    glLinkProgram(programID);
 
-	GLint result;
-	GLint infoLogLength;
-	glGetProgramiv(programID, GL_LINK_STATUS, &result);
-	glGetProgramiv(programID, GL_INFO_LOG_LENGTH, &infoLogLength);
-	if (infoLogLength > 0) {
-		std::vector<char> programErrorMessage(infoLogLength + 1);
-		glGetProgramInfoLog(programID, infoLogLength, NULL, &programErrorMessage[0]);
-		printf("%s\n", &programErrorMessage[0]);
-	}
+    GLint result;
+    GLint infoLogLength;
+    glGetProgramiv(programID, GL_LINK_STATUS, &result);
+    glGetProgramiv(programID, GL_INFO_LOG_LENGTH, &infoLogLength);
+    if (infoLogLength > 0) {
+        std::vector<char> programErrorMessage(infoLogLength + 1);
+        glGetProgramInfoLog(programID, infoLogLength, NULL, &programErrorMessage[0]);
+        printf("%s\n", &programErrorMessage[0]);
+    }
 }
 
 void IEPipeline::_vulkanCreate(IERenderEngine *engineLink, IEPipeline::CreateInfo *createInfo) {
-	linkedRenderEngine = engineLink;
-	createdWith = *createInfo;
-	// Create pipelineLayout
-	VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-			.setLayoutCount=1,
-			.pSetLayouts=&createdWith.descriptorSet.lock()->descriptorSetLayout,
-	};
-	if (vkCreatePipelineLayout(linkedRenderEngine->device.device, &pipelineLayoutCreateInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_WARN, "Failed to create pipeline layout!");
-	}
-	#ifndef NDEBUG
-	created.pipelineLayout = true;
-	#endif
-	deletionQueue.emplace_back([&] {
-		#ifndef NDEBUG
-		if (created.pipelineLayout) {
-			#endif
-			vkDestroyPipelineLayout(linkedRenderEngine->device.device, pipelineLayout, nullptr);
-			#ifndef NDEBUG
-			created.pipelineLayout = false;
-		}
-		#endif
-	});
+    linkedRenderEngine = engineLink;
+    createdWith        = *createInfo;
+    // Create pipelineLayout
+    VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo{
+      .sType          = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+      .setLayoutCount = 1,
+      .pSetLayouts    = &createdWith.descriptorSet.lock()->descriptorSetLayout,
+    };
+    if (vkCreatePipelineLayout(linkedRenderEngine->device.device, &pipelineLayoutCreateInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_WARN,
+          "Failed to create pipeline layout!"
+        );
+    }
+#ifndef NDEBUG
+    created.pipelineLayout = true;
+#endif
+    deletionQueue.emplace_back([&] {
+#ifndef NDEBUG
+        if (created.pipelineLayout) {
+#endif
+            vkDestroyPipelineLayout(linkedRenderEngine->device.device, pipelineLayout, nullptr);
+#ifndef NDEBUG
+            created.pipelineLayout = false;
+        }
+#endif
+    });
 
-	// Prepare shaders
-	std::array<VkShaderStageFlagBits, 2> shaderStages{VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
-	std::vector<VkPipelineShaderStageCreateInfo> shaders{};
-	for (uint32_t i = 0; i < createdWith.shaders.size(); i++) {
-		VkPipelineShaderStageCreateInfo shaderStageInfo{
-				.sType=VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-				.stage=shaderStages[i],
-				.module=createdWith.shaders[i]->module,
-				.pName="main",
-		};
-		shaders.push_back(shaderStageInfo);
-	}
+    // Prepare shaders
+    std::array<VkShaderStageFlagBits, 2> shaderStages{VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
+    std::vector<VkPipelineShaderStageCreateInfo> shaders{};
+    for (uint32_t i = 0; i < createdWith.shaders.size(); i++) {
+        VkPipelineShaderStageCreateInfo shaderStageInfo{
+          .sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+          .stage  = shaderStages[i],
+          .module = createdWith.shaders[i]->module,
+          .pName  = "main",
+        };
+        shaders.push_back(shaderStageInfo);
+    }
 
-	// Create graphics pipeline
-	VkVertexInputBindingDescription bindingDescription = IEVertex::getBindingDescription();
-	std::array<VkVertexInputAttributeDescription, 6> attributeDescriptions = IEVertex::getAttributeDescriptions();
-	VkPipelineVertexInputStateCreateInfo vertexInputStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
-			.vertexBindingDescriptionCount=1,
-			.pVertexBindingDescriptions=&bindingDescription,
-			.vertexAttributeDescriptionCount=static_cast<uint32_t>(attributeDescriptions.size()),
-			.pVertexAttributeDescriptions=attributeDescriptions.data(),
-	};
-	VkPipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
-			.topology=VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
-			.primitiveRestartEnable=VK_FALSE,
-	};
-	VkViewport viewport{
-			.x=0.0F,
-			.y=0.0F,
-			.width=(float) linkedRenderEngine->swapchain.extent.width,
-			.height=(float) linkedRenderEngine->swapchain.extent.height,
-			.minDepth=0.0F,
-			.maxDepth=1.0F,
-	};
-	VkRect2D scissor{
-			.offset={0, 0},
-			.extent=linkedRenderEngine->swapchain.extent,
-	};
-	VkPipelineViewportStateCreateInfo viewportStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
-			.viewportCount=1,
-			.pViewports=&viewport,
-			.scissorCount=1,
-			.pScissors=&scissor,
-	};
-	VkPipelineRasterizationStateCreateInfo rasterizationStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
-			.depthClampEnable=VK_FALSE,
-			.rasterizerDiscardEnable=VK_FALSE,
-			.polygonMode=VK_POLYGON_MODE_FILL, //Controls fill mode (e.g. wireframe mode,
-			.cullMode=VK_CULL_MODE_BACK_BIT,
-			.frontFace=VK_FRONT_FACE_COUNTER_CLOCKWISE,
-			.depthBiasEnable=VK_FALSE,
-			.lineWidth=1.0F,
-	};
-	VkPipelineMultisampleStateCreateInfo multisampleStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
-			.rasterizationSamples=static_cast<VkSampleCountFlagBits>(linkedRenderEngine->settings->msaaSamples),
-	};
-	if (linkedRenderEngine->device.physical_device.features.sampleRateShading != 0U) {
-		multisampleStateCreateInfo.sampleShadingEnable = linkedRenderEngine->settings->msaaSamples >= VK_SAMPLE_COUNT_1_BIT ? VK_TRUE : VK_FALSE;
-		multisampleStateCreateInfo.minSampleShading = 1.0F;
-	}
-	VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
-			.depthTestEnable=VK_TRUE,
-			.depthWriteEnable=VK_TRUE,
-			.depthCompareOp=VK_COMPARE_OP_LESS_OR_EQUAL,
-			.depthBoundsTestEnable=VK_FALSE,
-			.stencilTestEnable=VK_FALSE,
-			.back={
-					.compareOp=VK_COMPARE_OP_ALWAYS,
-			}
-	};
-	VkPipelineColorBlendAttachmentState colorBlendAttachmentState{
-			.blendEnable=linkedRenderEngine->settings->rayTracing ? VK_FALSE : VK_TRUE,
-			.srcColorBlendFactor=VK_BLEND_FACTOR_SRC_ALPHA,
-			.dstColorBlendFactor=VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
-			.colorBlendOp=VK_BLEND_OP_ADD,
-			.srcAlphaBlendFactor=VK_BLEND_FACTOR_ONE,
-			.dstAlphaBlendFactor=VK_BLEND_FACTOR_ZERO,
-			.alphaBlendOp=VK_BLEND_OP_ADD,
-			.colorWriteMask=VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
-	};
-	VkPipelineColorBlendStateCreateInfo colorBlendStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
-			.logicOpEnable=VK_FALSE,
-			.attachmentCount=1,
-			.pAttachments=&colorBlendAttachmentState,
-	};
-	VkDynamicState dynamicStates[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
-	VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
-			.dynamicStateCount=2,
-			.pDynamicStates=dynamicStates,
-	};
-	VkGraphicsPipelineCreateInfo pipelineCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
-			.stageCount=2,
-			.pStages=shaders.data(),
-			.pVertexInputState=&vertexInputStateCreateInfo,
-			.pInputAssemblyState=&inputAssemblyStateCreateInfo,
-			.pViewportState=&viewportStateCreateInfo,
-			.pRasterizationState=&rasterizationStateCreateInfo,
-			.pMultisampleState=&multisampleStateCreateInfo,
-			.pDepthStencilState=&pipelineDepthStencilStateCreateInfo,
-			.pColorBlendState=&colorBlendStateCreateInfo,
-			.pDynamicState=&pipelineDynamicStateCreateInfo,
-			.layout=pipelineLayout,
-			.renderPass=createdWith.renderPass.lock()->renderPass,
-			.basePipelineHandle=VK_NULL_HANDLE
-	};
-	if (vkCreateGraphicsPipelines(linkedRenderEngine->device.device, VK_NULL_HANDLE, 1, &pipelineCreateInfo, nullptr, &pipeline) != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR, "Failed to create pipeline!");
-	}
-	deletionQueue.emplace_back([&] {
-		vkDestroyPipeline(linkedRenderEngine->device.device, pipeline, nullptr);
-	});
+    // Create graphics pipeline
+    VkVertexInputBindingDescription                  bindingDescription    = IEVertex::getBindingDescription();
+    std::array<VkVertexInputAttributeDescription, 6> attributeDescriptions = IEVertex::getAttributeDescriptions();
+    VkPipelineVertexInputStateCreateInfo             vertexInputStateCreateInfo{
+                  .sType                           = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+                  .vertexBindingDescriptionCount   = 1,
+                  .pVertexBindingDescriptions      = &bindingDescription,
+                  .vertexAttributeDescriptionCount = static_cast<uint32_t>(attributeDescriptions.size()),
+                  .pVertexAttributeDescriptions    = attributeDescriptions.data(),
+    };
+    VkPipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo{
+      .sType                  = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+      .topology               = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+      .primitiveRestartEnable = VK_FALSE,
+    };
+    VkViewport viewport{
+      .x        = 0.0F,
+      .y        = 0.0F,
+      .width    = (float) linkedRenderEngine->swapchain.extent.width,
+      .height   = (float) linkedRenderEngine->swapchain.extent.height,
+      .minDepth = 0.0F,
+      .maxDepth = 1.0F,
+    };
+    VkRect2D scissor{
+      .offset = {0, 0},
+      .extent = linkedRenderEngine->swapchain.extent,
+    };
+    VkPipelineViewportStateCreateInfo viewportStateCreateInfo{
+      .sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+      .viewportCount = 1,
+      .pViewports    = &viewport,
+      .scissorCount  = 1,
+      .pScissors     = &scissor,
+    };
+    VkPipelineRasterizationStateCreateInfo rasterizationStateCreateInfo{
+      .sType                   = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+      .depthClampEnable        = VK_FALSE,
+      .rasterizerDiscardEnable = VK_FALSE,
+      .polygonMode             = VK_POLYGON_MODE_FILL,  // Controls fill mode (e.g. wireframe mode,
+      .cullMode                = VK_CULL_MODE_BACK_BIT,
+      .frontFace               = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+      .depthBiasEnable         = VK_FALSE,
+      .lineWidth               = 1.0F,
+    };
+    VkPipelineMultisampleStateCreateInfo multisampleStateCreateInfo{
+      .sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+      .rasterizationSamples = static_cast<VkSampleCountFlagBits>(linkedRenderEngine->settings->msaaSamples),
+    };
+    if (linkedRenderEngine->device.physical_device.features.sampleRateShading != 0U) {
+        multisampleStateCreateInfo.sampleShadingEnable =
+          linkedRenderEngine->settings->msaaSamples >= VK_SAMPLE_COUNT_1_BIT ? VK_TRUE : VK_FALSE;
+        multisampleStateCreateInfo.minSampleShading = 1.0F;
+    }
+    VkPipelineDepthStencilStateCreateInfo pipelineDepthStencilStateCreateInfo{
+      .sType                 = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
+      .depthTestEnable       = VK_TRUE,
+      .depthWriteEnable      = VK_TRUE,
+      .depthCompareOp        = VK_COMPARE_OP_LESS_OR_EQUAL,
+      .depthBoundsTestEnable = VK_FALSE,
+      .stencilTestEnable     = VK_FALSE,
+      .back                  = {
+                                .compareOp = VK_COMPARE_OP_ALWAYS,
+                                }
+    };
+    VkPipelineColorBlendAttachmentState colorBlendAttachmentState{
+      .blendEnable         = linkedRenderEngine->settings->rayTracing ? VK_FALSE : VK_TRUE,
+      .srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
+      .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+      .colorBlendOp        = VK_BLEND_OP_ADD,
+      .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+      .dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+      .alphaBlendOp        = VK_BLEND_OP_ADD,
+      .colorWriteMask =
+        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+    };
+    VkPipelineColorBlendStateCreateInfo colorBlendStateCreateInfo{
+      .sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+      .logicOpEnable   = VK_FALSE,
+      .attachmentCount = 1,
+      .pAttachments    = &colorBlendAttachmentState,
+    };
+    VkDynamicState                   dynamicStates[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+    VkPipelineDynamicStateCreateInfo pipelineDynamicStateCreateInfo{
+      .sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+      .dynamicStateCount = 2,
+      .pDynamicStates    = dynamicStates,
+    };
+    VkGraphicsPipelineCreateInfo pipelineCreateInfo{
+      .sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+      .stageCount          = 2,
+      .pStages             = shaders.data(),
+      .pVertexInputState   = &vertexInputStateCreateInfo,
+      .pInputAssemblyState = &inputAssemblyStateCreateInfo,
+      .pViewportState      = &viewportStateCreateInfo,
+      .pRasterizationState = &rasterizationStateCreateInfo,
+      .pMultisampleState   = &multisampleStateCreateInfo,
+      .pDepthStencilState  = &pipelineDepthStencilStateCreateInfo,
+      .pColorBlendState    = &colorBlendStateCreateInfo,
+      .pDynamicState       = &pipelineDynamicStateCreateInfo,
+      .layout              = pipelineLayout,
+      .renderPass          = createdWith.renderPass.lock()->renderPass,
+      .basePipelineHandle  = VK_NULL_HANDLE};
+    if (vkCreateGraphicsPipelines(linkedRenderEngine->device.device, VK_NULL_HANDLE, 1, &pipelineCreateInfo, nullptr, &pipeline) != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to create pipeline!"
+        );
+    }
+    deletionQueue.emplace_back([&] { vkDestroyPipeline(linkedRenderEngine->device.device, pipeline, nullptr); });
 }
 
-
 IEPipeline::~IEPipeline() {
-	destroy();
+    destroy();
 }

--- a/src/GraphicsModule/Shader/IEPipeline.hpp
+++ b/src/GraphicsModule/Shader/IEPipeline.hpp
@@ -9,8 +9,8 @@ class IERenderPass;
 
 /* Include classes used as attributes or function arguments. */
 // Internal dependencies
-#include "GraphicsModule/Shader/IEShader.hpp"
 #include "GraphicsModule/CommandBuffer/IEDependency.hpp"
+#include "GraphicsModule/Shader/IEShader.hpp"
 
 // External dependencies
 #include <vulkan/vulkan.h>
@@ -19,43 +19,42 @@ class IERenderPass;
 #include <functional>
 #include <vector>
 
-
 class IEPipeline : public IEDependency {
 public:
-	struct CreateInfo {
-		//Required
-		std::vector<std::shared_ptr<IEShader>> shaders{};
-		std::weak_ptr<IEDescriptorSet> descriptorSet{};
-		std::weak_ptr<IERenderPass> renderPass{};
-	};
+    struct CreateInfo {
+        // Required
+        std::vector<std::shared_ptr<IEShader>> shaders{};
+        std::weak_ptr<IEDescriptorSet>         descriptorSet{};
+        std::weak_ptr<IERenderPass>            renderPass{};
+    };
 
-	#ifndef NDEBUG
-	struct Created {
-		bool pipelineLayout{};
-	} created;
-	#endif
+#ifndef NDEBUG
+    struct Created {
+        bool pipelineLayout{};
+    } created;
+#endif
 
-	VkPipelineLayout pipelineLayout{};
-	CreateInfo createdWith{};
-	VkPipeline pipeline{};
-	GLuint programID{};
+    VkPipelineLayout pipelineLayout{};
+    CreateInfo       createdWith{};
+    VkPipeline       pipeline{};
+    GLuint           programID{};
 
-	void destroy();
+    void destroy();
 
-	void create(IERenderEngine *engineLink, CreateInfo *createInfo);
+    void create(IERenderEngine *engineLink, CreateInfo *createInfo);
 
-	~IEPipeline() override;
+    ~IEPipeline() override;
 
-	static void setAPI(const IEAPI &API);
+    static void setAPI(const IEAPI &API);
 
 private:
-	static std::function<void(IEPipeline &, IERenderEngine *, IEPipeline::CreateInfo *)> _create;
+    static std::function<void(IEPipeline &, IERenderEngine *, IEPipeline::CreateInfo *)> _create;
 
 protected:
-	void _vulkanCreate(IERenderEngine *, IEPipeline::CreateInfo *);
+    void _vulkanCreate(IERenderEngine *, IEPipeline::CreateInfo *);
 
-	void _openglCreate(IERenderEngine *, IEPipeline::CreateInfo *);
+    void _openglCreate(IERenderEngine *, IEPipeline::CreateInfo *);
 
-	IERenderEngine *linkedRenderEngine{};
-	std::vector<std::function<void()>> deletionQueue{};
+    IERenderEngine                    *linkedRenderEngine{};
+    std::vector<std::function<void()>> deletionQueue{};
 };

--- a/src/GraphicsModule/Shader/IEShader.cpp
+++ b/src/GraphicsModule/Shader/IEShader.cpp
@@ -9,100 +9,98 @@
 #include "Core/FileSystemModule/IEFile.hpp"
 
 void IEShader::setAPI(const IEAPI &API) {
-	if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
-		_create = &IEShader::_openglCreate;
-		_compile = &IEShader::_openglCompile;
-	} else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
-		_create = &IEShader::_vulkanCreate;
-		_compile = &IEShader::_vulkanCompile;
-	}
+    if (API.name == IE_RENDER_ENGINE_API_NAME_OPENGL) {
+        _create  = &IEShader::_openglCreate;
+        _compile = &IEShader::_openglCompile;
+    } else if (API.name == IE_RENDER_ENGINE_API_NAME_VULKAN) {
+        _create  = &IEShader::_vulkanCreate;
+        _compile = &IEShader::_vulkanCompile;
+    }
 }
 
 void IEShader::destroy() {
-	for (const std::function<void()> &function: deletionQueue) {
-		function();
-	}
-	deletionQueue.clear();
+    for (const std::function<void()> &function : deletionQueue) function();
+    deletionQueue.clear();
 }
-
 
 std::function<void(IEShader &, IERenderEngine *, IEFile *)> IEShader::_create = nullptr;
 
 void IEShader::create(IERenderEngine *engineLink, IEFile *shaderFile) {
-	_create(*this, engineLink, shaderFile);
+    _create(*this, engineLink, shaderFile);
 }
 
 void IEShader::_openglCreate(IERenderEngine *renderEngineLink, IEFile *shaderFile) {
-	file = shaderFile;
-	linkedRenderEngine = renderEngineLink;
-	GLenum shaderType = GL_VERTEX_SHADER;
-	if (file->extensions()[0] == "frag") shaderType = GL_FRAGMENT_SHADER;
-	shaderID = glCreateShader(shaderType);
-	compile(file->path, file->path);
+    file               = shaderFile;
+    linkedRenderEngine = renderEngineLink;
+    GLenum shaderType  = GL_VERTEX_SHADER;
+    if (file->extensions()[0] == "frag") shaderType = GL_FRAGMENT_SHADER;
+    shaderID = glCreateShader(shaderType);
+    compile(file->path, file->path);
 }
 
 void IEShader::_vulkanCreate(IERenderEngine *renderEngineLink, IEFile *shaderFile) {
-	file = shaderFile;
-	linkedRenderEngine = renderEngineLink;
-	std::vector<std::string> extensions = file->extensions();
-	std::string fileContents;
-	if (std::find(extensions.begin(), extensions.end(), "spv") == extensions.end()) {
-		compile(file->path, file->path + ".spv");
-		file = new IEFile{file->path + ".spv"};
-	}
-	file->open();
-	fileContents = file->read((size_t)file->length, 0);
-	file->close();
-	VkShaderModuleCreateInfo shaderModuleCreateInfo{
-			.sType=VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
-			.codeSize=static_cast<size_t>(file->length),
-			.pCode=reinterpret_cast<const uint32_t *>(fileContents.data()),
-	};
-	VkResult result = vkCreateShaderModule(linkedRenderEngine->device.device, &shaderModuleCreateInfo, nullptr, &module);
-	if (result != VK_SUCCESS) {
-		linkedRenderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
-												 "Failed to create shader module! Error: " + IERenderEngine::translateVkResultCodes(result));
-	} else {
-		deletionQueue.emplace_back([&] {
-			vkDestroyShaderModule(linkedRenderEngine->device.device, module, nullptr);
-		});
-	}
+    file                                = shaderFile;
+    linkedRenderEngine                  = renderEngineLink;
+    std::vector<std::string> extensions = file->extensions();
+    std::string              fileContents;
+    if (std::find(extensions.begin(), extensions.end(), "spv") == extensions.end()) {
+        compile(file->path, file->path + ".spv");
+        file = new IEFile{file->path + ".spv"};
+    }
+    file->open();
+    fileContents = file->read((size_t) file->length, 0);
+    file->close();
+    VkShaderModuleCreateInfo shaderModuleCreateInfo{
+      .sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+      .codeSize = static_cast<size_t>(file->length),
+      .pCode    = reinterpret_cast<const uint32_t *>(fileContents.data()),
+    };
+    VkResult result =
+      vkCreateShaderModule(linkedRenderEngine->device.device, &shaderModuleCreateInfo, nullptr, &module);
+    if (result != VK_SUCCESS) {
+        linkedRenderEngine->settings->logger.log(
+          ILLUMINATION_ENGINE_LOG_LEVEL_ERROR,
+          "Failed to create shader module! Error: " + IERenderEngine::translateVkResultCodes(result)
+        );
+    } else {
+        deletionQueue.emplace_back([&] {
+            vkDestroyShaderModule(linkedRenderEngine->device.device, module, nullptr);
+        });
+    }
 }
 
 IEShader::~IEShader() {
-	destroy();
+    destroy();
 }
 
 std::function<void(IEShader &, const std::string &, std::string)> IEShader::_compile{nullptr};
 
 void IEShader::compile(const std::string &input, const std::string &output) {
-	_compile(*this, input, output);
+    _compile(*this, input, output);
 }
 
 void IEShader::_openglCompile(const std::string &input, std::string) {
-	file->open();
-	std::string contents = file->read((size_t) file->length, 0);
+    file->open();
+    std::string contents = file->read((size_t) file->length, 0);
 
-	// Compile shader
-	GLint result = GL_FALSE;
-	int infoLogLength;
-	const GLchar *shader = contents.c_str();
-	glShaderSource(shaderID, 1, &shader, nullptr);
-	glCompileShader(shaderID);
-	glGetShaderiv(shaderID, GL_COMPILE_STATUS, &result);
-	glGetShaderiv(shaderID, GL_INFO_LOG_LENGTH, &infoLogLength);
-	if (infoLogLength > 0) {
-		std::vector<char> shaderErrorMessage(infoLogLength + 1);
-		glGetShaderInfoLog(shaderID, infoLogLength, nullptr, &shaderErrorMessage[0]);
-		printf("%s\n", &shaderErrorMessage[0]);
-	}
+    // Compile shader
+    GLint         result = GL_FALSE;
+    int           infoLogLength;
+    const GLchar *shader = contents.c_str();
+    glShaderSource(shaderID, 1, &shader, nullptr);
+    glCompileShader(shaderID);
+    glGetShaderiv(shaderID, GL_COMPILE_STATUS, &result);
+    glGetShaderiv(shaderID, GL_INFO_LOG_LENGTH, &infoLogLength);
+    if (infoLogLength > 0) {
+        std::vector<char> shaderErrorMessage(infoLogLength + 1);
+        glGetShaderInfoLog(shaderID, infoLogLength, nullptr, &shaderErrorMessage[0]);
+        printf("%s\n", &shaderErrorMessage[0]);
+    }
 }
 
 void IEShader::_vulkanCompile(const std::string &input, std::string output) {
-	if (output.empty()) {
-		output = input + ".spv";
-	}
-//	if (system((GLSLC + input + " -o " + output).c_str()) != 0) {
-//		throw std::runtime_error("failed to compile shaders: " + input);
-//	}
+    if (output.empty()) output = input + ".spv";
+    //	if (system((GLSLC + input + " -o " + output).c_str()) != 0) {
+    //		throw std::runtime_error("failed to compile shaders: " + input);
+    //	}
 }

--- a/src/GraphicsModule/Shader/IEShader.hpp
+++ b/src/GraphicsModule/Shader/IEShader.hpp
@@ -2,9 +2,9 @@
 
 /* Define macros used throughout the file. */
 #ifdef WIN32
-#define GLSLC "glslc.exe "
+#    define GLSLC "glslc.exe "
 #else
-#define GLSLC "glslc "
+#    define GLSLC "glslc "
 #endif
 
 /* Predefine classes used with pointers or as return values for functions. */
@@ -17,46 +17,47 @@ class IERenderEngine;
 #include <vulkan/vulkan.h>
 
 // System dependencies
-#include <string>
-#include <vector>
-#include <functional>
 #include "Core/FileSystemModule/IEFile.hpp"
 
-#define GLEW_IMPLEMENTATION
-#include <include/GL/glew.h>
+#include <functional>
+#include <string>
+#include <vector>
 
+#define GLEW_IMPLEMENTATION
+
+#include <include/GL/glew.h>
 
 class IEShader {
 public:
-	std::vector<char> data;
-	std::vector<std::function<void()>> deletionQueue;
-	VkShaderModule module;
-	IERenderEngine *linkedRenderEngine;
-	IEFile *file;
-	GLuint shaderID;
+    std::vector<char>                  data;
+    std::vector<std::function<void()>> deletionQueue;
+    VkShaderModule                     module;
+    IERenderEngine                    *linkedRenderEngine;
+    IEFile                            *file;
+    GLuint                             shaderID;
 
 private:
-	static std::function<void(IEShader &, IERenderEngine *, IEFile *)> _create;
-	static std::function<void(IEShader &, const std::string &, std::string)> _compile;
+    static std::function<void(IEShader &, IERenderEngine *, IEFile *)>       _create;
+    static std::function<void(IEShader &, const std::string &, std::string)> _compile;
 
 protected:
-	void _openglCompile(const std::string &, std::string);
+    void _openglCompile(const std::string &, std::string);
 
-	void _vulkanCompile(const std::string &, std::string);
+    void _vulkanCompile(const std::string &, std::string);
 
 
-	void _openglCreate(IERenderEngine *, IEFile *);
+    void _openglCreate(IERenderEngine *, IEFile *);
 
-	void _vulkanCreate(IERenderEngine *, IEFile *);
+    void _vulkanCreate(IERenderEngine *, IEFile *);
 
 public:
-	void destroy();
+    void destroy();
 
-	~IEShader();
+    ~IEShader();
 
-	void compile(const std::string &, const std::string &);
+    void compile(const std::string &, const std::string &);
 
-	void create(IERenderEngine *, IEFile *);
+    void create(IERenderEngine *, IEFile *);
 
-	static void setAPI(const IEAPI &);
+    static void setAPI(const IEAPI &);
 };

--- a/src/GraphicsModule/Shader/IEUniformBufferObject.cpp
+++ b/src/GraphicsModule/Shader/IEUniformBufferObject.cpp
@@ -2,11 +2,16 @@
 #include "IEUniformBufferObject.hpp"
 
 void IEUniformBufferObject::openglUploadUniform(GLint program) {
-	glUseProgram(program);
-	glUniformMatrix4fv(glGetUniformLocation(program, "projectionViewModelMatrix"), 1, GL_FALSE, &projectionViewModelMatrix[0][0]);
-	glUniformMatrix4fv(glGetUniformLocation(program, "modelMatrix"), 1, GL_FALSE, &modelMatrix[0][0]);
-	glUniformMatrix4fv(glGetUniformLocation(program, "normalMatrix"), 1, GL_FALSE, &normalMatrix[0][0]);
-	glUniform3fv(glGetUniformLocation(program, "position"), 1, &position[0]);
-	glUniform1f(glGetUniformLocation(program, "time"), time);
-	glUseProgram(0);
+    glUseProgram(program);
+    glUniformMatrix4fv(
+      glGetUniformLocation(program, "projectionViewModelMatrix"),
+      1,
+      GL_FALSE,
+      &projectionViewModelMatrix[0][0]
+    );
+    glUniformMatrix4fv(glGetUniformLocation(program, "modelMatrix"), 1, GL_FALSE, &modelMatrix[0][0]);
+    glUniformMatrix4fv(glGetUniformLocation(program, "normalMatrix"), 1, GL_FALSE, &normalMatrix[0][0]);
+    glUniform3fv(glGetUniformLocation(program, "position"), 1, &position[0]);
+    glUniform1f(glGetUniformLocation(program, "time"), time);
+    glUseProgram(0);
 }

--- a/src/GraphicsModule/Shader/IEUniformBufferObject.hpp
+++ b/src/GraphicsModule/Shader/IEUniformBufferObject.hpp
@@ -3,19 +3,22 @@
 /* Include classes used as attributes or function arguments. */
 // External dependencies
 #define GLM_FORCE_RADIANS
+
 #include "glm/glm.hpp"
+
 #include <string>
 
 #define GLEW_IMPLEMENTATION
+
 #include <include/GL/glew.h>
 
 struct IEUniformBufferObject {
 public:
-	alignas(16) glm::mat4 projectionViewModelMatrix{};
-	alignas(16) glm::mat4 modelMatrix{};
-	alignas(16) glm::mat4 normalMatrix{};
-	alignas(16) glm::vec3 position{0, 0, 0};
-	alignas(4) glm::float32 time{};
-	
-	void openglUploadUniform(GLint program);
+    alignas(16) glm::mat4 projectionViewModelMatrix{};
+    alignas(16) glm::mat4 modelMatrix{};
+    alignas(16) glm::mat4 normalMatrix{};
+    alignas(16) glm::vec3 position{0, 0, 0};
+    alignas(4) glm::float32 time{};
+
+    void openglUploadUniform(GLint program);
 };

--- a/src/InputModule/IEKeyboard.cpp
+++ b/src/InputModule/IEKeyboard.cpp
@@ -1,31 +1,35 @@
 #include "IEKeyboard.hpp"
 
 IEKeyPressDescription::IEKeyPressDescription(int initialKey, int initialAction, int initialModifiers) {
-    key = initialKey;
-    scancode = glfwGetKeyScancode(key);
-    action = initialAction;
+    key       = initialKey;
+    scancode  = glfwGetKeyScancode(key);
+    action    = initialAction;
     modifiers = initialModifiers;
 }
 
 IEKeyPressDescription::IEKeyPressDescription(int initialKey) {
-    key = initialKey;
-    scancode = glfwGetKeyScancode(key);
-    action = GLFW_PRESS;
+    key       = initialKey;
+    scancode  = glfwGetKeyScancode(key);
+    action    = GLFW_PRESS;
     modifiers = 0;
 }
 
 bool IEKeyPressDescription::operator==(const IEKeyPressDescription &other) const {
-    return static_cast<int>((this->key == other.key) & static_cast<int>(this->scancode == other.scancode) &
-                            static_cast<int>(this->action == other.action) & static_cast<int>(this->modifiers == other.modifiers)) != 0;
+    return static_cast<int>(
+             (this->key == other.key) & static_cast<int>(this->scancode == other.scancode) &
+             static_cast<int>(this->action == other.action) & static_cast<int>(this->modifiers == other.modifiers)
+           ) != 0;
 }
 
 size_t std::hash<IEKeyPressDescription>::operator()(const IEKeyPressDescription &k) const {
-    return ((((std::hash<int>()(k.key) ^ std::hash<int>()(k.scancode) >> 1) << 1) ^ std::hash<int>()(k.action) << 1) << 1) ^
-           std::hash<int>()(k.modifiers);
+    return ((((std::hash<int>()(k.key) ^ std::hash<int>()(k.scancode) >> 1) << 1) ^ std::hash<int>()(k.action) << 1
+            )
+            << 1) ^
+      std::hash<int>()(k.modifiers);
 }
 
 IEKeyboard::IEKeyboard(GLFWwindow *initialWindow, void *initialAttachment) {
-    window = initialWindow;
+    window     = initialWindow;
     attachment = initialAttachment;
     glfwSetKeyCallback(window, keyCallback);
 }
@@ -35,20 +39,21 @@ void IEKeyboard::setEnqueueMethod(GLFWkeyfun function) {
 }
 
 void IEKeyboard::handleQueue() {
-    for (const IEKeyPressDescription &i: queue) {
+    for (const IEKeyPressDescription &i : queue) {
         auto element = actionsOptions.find(i);
         if (element != actionsOptions.end()) {  // for each element that has a correlating action
             element->second.first(window);
-            if (static_cast<int>((!element->second.second) | static_cast<int>(i.action == GLFW_RELEASE)) !=
-                0) { // remove elements labeled to not repeat or release
+            if (static_cast<int>((!element->second.second) | static_cast<int>(i.action == GLFW_RELEASE)) != 0) {  // remove elements labeled to not repeat or release
                 queue.erase(std::find(queue.begin(), queue.end(), i));
             }
         }
     }
 }
 
-void IEKeyboard::editActions(const IEKeyPressDescription &keyPressDescription,
-                             const std::pair<std::function<void(GLFWwindow *)>, bool> &action) {
+void IEKeyboard::editActions(
+  const IEKeyPressDescription                              &keyPressDescription,
+  const std::pair<std::function<void(GLFWwindow *)>, bool> &action
+) {
     actionsOptions.erase(keyPressDescription);
     actionsOptions.insert({keyPressDescription, action});
 }
@@ -59,30 +64,50 @@ void IEKeyboard::editActions(uint16_t key, const std::pair<std::function<void(GL
     actionsOptions.insert({keyPressDescription, action});
 }
 
-void IEKeyboard::editActions(uint16_t key, uint16_t keyAction, uint16_t modifiers,
-                             const std::pair<std::function<void(GLFWwindow *)>, bool> &action) {
+void IEKeyboard::editActions(
+  uint16_t                                                  key,
+  uint16_t                                                  keyAction,
+  uint16_t                                                  modifiers,
+  const std::pair<std::function<void(GLFWwindow *)>, bool> &action
+) {
     IEKeyPressDescription keyPressDescription{key, keyAction, modifiers};
     actionsOptions.erase(keyPressDescription);
     actionsOptions.insert({keyPressDescription, action});
 }
 
-void IEKeyboard::editActions(const IEKeyPressDescription &keyPressDescription,
-                             const std::function<void(GLFWwindow *)> &action) {
+void IEKeyboard::editActions(
+  const IEKeyPressDescription             &keyPressDescription,
+  const std::function<void(GLFWwindow *)> &action
+) {
     actionsOptions.erase(keyPressDescription);
-    actionsOptions.insert({keyPressDescription, {action, keyPressDescription.action == GLFW_REPEAT}});
+    actionsOptions.insert({
+      keyPressDescription,
+      {action, keyPressDescription.action == GLFW_REPEAT}
+    });
 }
 
 void IEKeyboard::editActions(uint16_t key, const std::function<void(GLFWwindow *)> &action, bool repeat) {
     IEKeyPressDescription keyPressDescription{key};
     actionsOptions.erase(keyPressDescription);
-    actionsOptions.insert({keyPressDescription, {action, repeat}});
+    actionsOptions.insert({
+      keyPressDescription,
+      {action, repeat}
+    });
 }
 
-void IEKeyboard::editActions(uint16_t key, uint16_t keyAction, uint16_t modifiers,
-                             const std::function<void(GLFWwindow *)> &action, bool repeat) {
+void IEKeyboard::editActions(
+  uint16_t                                 key,
+  uint16_t                                 keyAction,
+  uint16_t                                 modifiers,
+  const std::function<void(GLFWwindow *)> &action,
+  bool                                     repeat
+) {
     IEKeyPressDescription keyPressDescription{key, keyAction, modifiers};
     actionsOptions.erase(keyPressDescription);
-    actionsOptions.insert({keyPressDescription, {action, repeat}});
+    actionsOptions.insert({
+      keyPressDescription,
+      {action, repeat}
+    });
 }
 
 void IEKeyboard::clearQueue() {
@@ -90,7 +115,8 @@ void IEKeyboard::clearQueue() {
 }
 
 void IEKeyboard::keyCallback(GLFWwindow *window, int key, int scancode, int action, int modifiers) {
-    auto keyboard = (IEKeyboard *) ((IEWindowUser *) (glfwGetWindowUserPointer(window)))->IEKeyboard; // keyboard connected to the window
+    auto keyboard = (IEKeyboard *) ((IEWindowUser *) (glfwGetWindowUserPointer(window)))
+                      ->IEKeyboard;  // keyboard connected to the window
     if (action == GLFW_REPEAT) {
         keyboard->queue.emplace_back(key, action);
         return;
@@ -98,8 +124,6 @@ void IEKeyboard::keyCallback(GLFWwindow *window, int key, int scancode, int acti
     IEKeyPressDescription thisKeyPress{key, action};
     IEKeyPressDescription oppositeKeyPress{key, thisKeyPress.action == GLFW_PRESS ? GLFW_RELEASE : GLFW_PRESS};
     auto oppositeKeyPressIterator = std::find(keyboard->queue.begin(), keyboard->queue.end(), oppositeKeyPress);
-    if (oppositeKeyPressIterator != keyboard->queue.end()) {
-        keyboard->queue.erase(oppositeKeyPressIterator);
-    }
+    if (oppositeKeyPressIterator != keyboard->queue.end()) keyboard->queue.erase(oppositeKeyPressIterator);
     keyboard->queue.push_back(thisKeyPress);
 }

--- a/src/InputModule/IEKeyboard.hpp
+++ b/src/InputModule/IEKeyboard.hpp
@@ -3,55 +3,55 @@
 #include "../Core/IEWindowUser.hpp"
 
 #ifndef GLEW_IMPLEMENTATION
-#define GLEW_IMPLEMENTATION
-#include <include/GL/glew.h>
+#    define GLEW_IMPLEMENTATION
+#    include <include/GL/glew.h>
 #endif
 
-#include <GLFW/glfw3.h>
-
-#include <functional>
-#include <vector>
 #include <any>
-#include <string>
 #include <cstdint>
+#include <functional>
+#include <GLFW/glfw3.h>
+#include <string>
+#include <vector>
 
 /**
  * @brief A class that stores the data related to a key press action.
  */
 struct IEKeyPressDescription {
-	uint16_t key;
-	uint8_t action;
-	uint8_t modifiers;
-	uint16_t scancode;
+    uint16_t key;
+    uint8_t  action;
+    uint8_t  modifiers;
+    uint16_t scancode;
 
-	/**
-	 * @brief Constructs a KeyPressDescription from a key, action and modifiers.
-	 * @param initialKey
-	 * @param initialAction
-	 * @param initialModifiers=0
-	 * @returns IeKeyPressDescription
-	 */
-	IEKeyPressDescription(int initialKey, int initialAction, int initialModifiers = 0);
+    /**
+     * @brief Constructs a KeyPressDescription from a key, action and modifiers.
+     * @param initialKey
+     * @param initialAction
+     * @param initialModifiers=0
+     * @returns IeKeyPressDescription
+     */
+    IEKeyPressDescription(int initialKey, int initialAction, int initialModifiers = 0);
 
-	/**
-	 * Constructs a KeyPressDescription from a key. Sets action to pressed with no modifiers.
-	 * @param initialKey
-	 */
-	explicit IEKeyPressDescription(int initialKey);
+    /**
+     * Constructs a KeyPressDescription from a key. Sets action to pressed with no modifiers.
+     * @param initialKey
+     */
+    explicit IEKeyPressDescription(int initialKey);
 
-	/**
-	 * @brief The == operator for the IeKeyPressDescription structure.
-	 * @param other
-	 * @return true if the values of the object and argument are the same, false if not.
-	 */
-	bool operator==(const IEKeyPressDescription &other) const;
+    /**
+     * @brief The == operator for the IeKeyPressDescription structure.
+     * @param other
+     * @return true if the values of the object and argument are the same, false if not.
+     */
+    bool operator==(const IEKeyPressDescription &other) const;
 };
 
 /**
  * @brief The hash method for the IeKeyPressDescription structure.
  * @return A hash value for an IeKeyPressDescription.
  */
-template<> struct [[maybe_unused]] std::hash<IEKeyPressDescription> {
+template<>
+struct [[maybe_unused]] std::hash<IEKeyPressDescription> {
     size_t operator()(const IEKeyPressDescription &k) const;
 };
 
@@ -60,94 +60,111 @@ template<> struct [[maybe_unused]] std::hash<IEKeyPressDescription> {
  */
 class IEKeyboard {
 public:
-	void *attachment; // pointer to object for access through the window user pointer
-	IEWindowUser windowUser;
+    void        *attachment;  // pointer to object for access through the window user pointer
+    IEWindowUser windowUser;
 
-	/**
-	 * @brief Constructs a keyboard from a initialWindow. The initialWindow's user pointer will be set to the IeKeyboard object.
-	 * @param initialWindow
-	 * @param initialAttachment=nullptr
-	 * @return IeKeyboard
-	 */
-	explicit IEKeyboard(GLFWwindow *initialWindow, void *initialAttachment = nullptr);
+    /**
+     * @brief Constructs a keyboard from a initialWindow. The initialWindow's user pointer will be set to the
+     * IeKeyboard object.
+     * @param initialWindow
+     * @param initialAttachment=nullptr
+     * @return IeKeyboard
+     */
+    explicit IEKeyboard(GLFWwindow *initialWindow, void *initialAttachment = nullptr);
 
-	/**
-	 * @brief Sets the queue method. Pass one of the two pre-created key event handler functions.
-	 * @param function
-	 */
-	void setEnqueueMethod(GLFWkeyfun function = keyCallback);
+    /**
+     * @brief Sets the queue method. Pass one of the two pre-created key event handler functions.
+     * @param function
+     */
+    void setEnqueueMethod(GLFWkeyfun function = keyCallback);
 
-	/**
-	 * @brief Handles all the actions indicated by the key presses logged in the queue.
-	 */
-	void handleQueue();
+    /**
+     * @brief Handles all the actions indicated by the key presses logged in the queue.
+     */
+    void handleQueue();
 
-	/**
-	 * @brief Adds or changes a key press to function correlation.
-	 * @param keyPressDescription
-	 * @param action
-	 */
-	void editActions(const IEKeyPressDescription &keyPressDescription, const std::pair<std::function<void(GLFWwindow *)>, bool> &action);
+    /**
+     * @brief Adds or changes a key press to function correlation.
+     * @param keyPressDescription
+     * @param action
+     */
+    void editActions(
+      const IEKeyPressDescription                              &keyPressDescription,
+      const std::pair<std::function<void(GLFWwindow *)>, bool> &action
+    );
 
-	/**
-	 * @brief Adds or changes key press to function correlation.
-	 * @param key
-	 * @param action
-	 */
-	void editActions(uint16_t key, const std::pair<std::function<void(GLFWwindow *)>, bool> &action);
+    /**
+     * @brief Adds or changes key press to function correlation.
+     * @param key
+     * @param action
+     */
+    void editActions(uint16_t key, const std::pair<std::function<void(GLFWwindow *)>, bool> &action);
 
-	/**
-	 * @brief Adds or changes key press to function correlation.
-	 * @param key
-	 * @param keyAction
-	 * @param modifiers
-	 * @param action
-	 */
-	void editActions(uint16_t key, uint16_t keyAction, uint16_t modifiers, const std::pair<std::function<void(GLFWwindow *)>, bool> &action);
+    /**
+     * @brief Adds or changes key press to function correlation.
+     * @param key
+     * @param keyAction
+     * @param modifiers
+     * @param action
+     */
+    void editActions(
+      uint16_t                                                  key,
+      uint16_t                                                  keyAction,
+      uint16_t                                                  modifiers,
+      const std::pair<std::function<void(GLFWwindow *)>, bool> &action
+    );
 
-	/**
-	 * @brief Adds or changes a key press to function correlation.
-	 * @param keyPressDescription
-	 * @param action
-	 * @param repeat
-	 */
-	void editActions(const IEKeyPressDescription &keyPressDescription, const std::function<void(GLFWwindow *)> &action);
+    /**
+     * @brief Adds or changes a key press to function correlation.
+     * @param keyPressDescription
+     * @param action
+     * @param repeat
+     */
+    void
+    editActions(const IEKeyPressDescription &keyPressDescription, const std::function<void(GLFWwindow *)> &action);
 
-	/**
-	 * @brief Adds or changes key press to function correlation.
-	 * @param key
-	 * @param action
-	 * @param repeat
-	 */
-	void editActions(uint16_t key, const std::function<void(GLFWwindow *)> &action, bool repeat = true);
+    /**
+     * @brief Adds or changes key press to function correlation.
+     * @param key
+     * @param action
+     * @param repeat
+     */
+    void editActions(uint16_t key, const std::function<void(GLFWwindow *)> &action, bool repeat = true);
 
-	/**
-	 * @brief Adds or changes key press to function correlation.
-	 * @param key
-	 * @param keyAction
-	 * @param modifiers
-	 * @param action
-	 * @param repeat
-	 */
-	void editActions(uint16_t key, uint16_t keyAction, uint16_t modifiers, const std::function<void(GLFWwindow *)> &action, bool repeat = true);
+    /**
+     * @brief Adds or changes key press to function correlation.
+     * @param key
+     * @param keyAction
+     * @param modifiers
+     * @param action
+     * @param repeat
+     */
+    void editActions(
+      uint16_t                                 key,
+      uint16_t                                 keyAction,
+      uint16_t                                 modifiers,
+      const std::function<void(GLFWwindow *)> &action,
+      bool                                     repeat = true
+    );
 
-	/**
-	 * @brief Clears the event queue.
-	 */
-	void clearQueue();
+    /**
+     * @brief Clears the event queue.
+     */
+    void clearQueue();
 
-	/**
-	 * @brief Default key event handler function. Enqueues the key as pressed or released. Does not handle repeats.
-	 * @param window
-	 * @param key
-	 * @param scancode
-	 * @param action
-	 * @param modifiers
-	 */
-	void static keyCallback(GLFWwindow *window, int key, int scancode, int action, int modifiers);
+    /**
+     * @brief Default key event handler function. Enqueues the key as pressed or released. Does not handle repeats.
+     * @param window
+     * @param key
+     * @param scancode
+     * @param action
+     * @param modifiers
+     */
+    static void keyCallback(GLFWwindow *window, int key, int scancode, int action, int modifiers);
 
 private:
-	GLFWwindow *window; // window this keyboard manages
-	std::vector<IEKeyPressDescription> queue{}; // queue of key presses
-	std::unordered_map<IEKeyPressDescription, std::pair<std::function<void(GLFWwindow *)>, bool>> actionsOptions{}; // hash table of key press description to function
+    GLFWwindow                        *window;   // window this keyboard manages
+    std::vector<IEKeyPressDescription> queue{};  // queue of key presses
+    std::unordered_map<IEKeyPressDescription, std::pair<std::function<void(GLFWwindow *)>, bool>>
+      actionsOptions{};  // hash table of key press description to function
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,55 +1,79 @@
+#include "Core/FileSystemModule/IEFileSystem.hpp"
 #include "GraphicsModule/IERenderEngine.hpp"
 #include "InputModule/IEKeyboard.hpp"
-#include "Core/FileSystemModule/IEFileSystem.hpp"
 
 int main() {
-	IESettings settings = IESettings();
-	// RenderEngine must be allocated on the heap.
-	std::shared_ptr<IERenderEngine> renderEngine = std::make_shared<IERenderEngine>(settings);
+    IESettings                      settings     = IESettings();
+    // RenderEngine must be allocated on the heap.
+    std::shared_ptr<IERenderEngine> renderEngine = std::make_shared<IERenderEngine>(settings);
 
-	IEKeyboard keyboard{renderEngine->window};
-	keyboard.editActions(GLFW_KEY_W, [&](GLFWwindow *) { renderEngine->camera.position += renderEngine->camera.front * renderEngine->frameTime * renderEngine->camera.speed; });
-	keyboard.editActions(GLFW_KEY_A, [&](GLFWwindow *) { renderEngine->camera.position -= renderEngine->camera.right * renderEngine->frameTime * renderEngine->camera.speed; });
-	keyboard.editActions(GLFW_KEY_S, [&](GLFWwindow *) { renderEngine->camera.position -= renderEngine->camera.front * renderEngine->frameTime * renderEngine->camera.speed; });
-	keyboard.editActions(GLFW_KEY_D, [&](GLFWwindow *) { renderEngine->camera.position += renderEngine->camera.right * renderEngine->frameTime * renderEngine->camera.speed; });
-	keyboard.editActions(GLFW_KEY_SPACE, [&](GLFWwindow *) { renderEngine->camera.position += renderEngine->camera.up * renderEngine->frameTime * renderEngine->camera.speed; });
-	keyboard.editActions(GLFW_KEY_LEFT_SHIFT, [&](GLFWwindow *) { renderEngine->camera.position -= renderEngine->camera.up * renderEngine->frameTime * renderEngine->camera.speed; });
-	keyboard.editActions({GLFW_KEY_LEFT_CONTROL, GLFW_PRESS}, [&](GLFWwindow *) { renderEngine->camera.speed *= 6; });
-	keyboard.editActions({GLFW_KEY_LEFT_CONTROL, GLFW_RELEASE}, [&](GLFWwindow *) { renderEngine->camera.speed /= 6; });
-	keyboard.editActions({GLFW_KEY_F11, GLFW_PRESS}, [&](GLFWwindow *) { renderEngine->toggleFullscreen(); });
-	keyboard.editActions({GLFW_KEY_ESCAPE, GLFW_REPEAT}, [&](GLFWwindow *) { glfwSetWindowShouldClose(renderEngine->window, 1); });
+    IEKeyboard keyboard{renderEngine->window};
+    keyboard.editActions(GLFW_KEY_W, [&](GLFWwindow *) {
+        renderEngine->camera.position +=
+          renderEngine->camera.front * renderEngine->frameTime * renderEngine->camera.speed;
+    });
+    keyboard.editActions(GLFW_KEY_A, [&](GLFWwindow *) {
+        renderEngine->camera.position -=
+          renderEngine->camera.right * renderEngine->frameTime * renderEngine->camera.speed;
+    });
+    keyboard.editActions(GLFW_KEY_S, [&](GLFWwindow *) {
+        renderEngine->camera.position -=
+          renderEngine->camera.front * renderEngine->frameTime * renderEngine->camera.speed;
+    });
+    keyboard.editActions(GLFW_KEY_D, [&](GLFWwindow *) {
+        renderEngine->camera.position +=
+          renderEngine->camera.right * renderEngine->frameTime * renderEngine->camera.speed;
+    });
+    keyboard.editActions(GLFW_KEY_SPACE, [&](GLFWwindow *) {
+        renderEngine->camera.position +=
+          renderEngine->camera.up * renderEngine->frameTime * renderEngine->camera.speed;
+    });
+    keyboard.editActions(GLFW_KEY_LEFT_SHIFT, [&](GLFWwindow *) {
+        renderEngine->camera.position -=
+          renderEngine->camera.up * renderEngine->frameTime * renderEngine->camera.speed;
+    });
+    keyboard.editActions({GLFW_KEY_LEFT_CONTROL, GLFW_PRESS}, [&](GLFWwindow *) {
+        renderEngine->camera.speed *= 6;
+    });
+    keyboard.editActions({GLFW_KEY_LEFT_CONTROL, GLFW_RELEASE}, [&](GLFWwindow *) {
+        renderEngine->camera.speed /= 6;
+    });
+    keyboard.editActions({GLFW_KEY_F11, GLFW_PRESS}, [&](GLFWwindow *) { renderEngine->toggleFullscreen(); });
+    keyboard.editActions({GLFW_KEY_ESCAPE, GLFW_REPEAT}, [&](GLFWwindow *) {
+        glfwSetWindowShouldClose(renderEngine->window, 1);
+    });
 
-	IEWindowUser windowUser{std::shared_ptr<IERenderEngine>(renderEngine), &keyboard};
-	glfwSetWindowUserPointer(renderEngine->window, &windowUser);
+    IEWindowUser windowUser{std::shared_ptr<IERenderEngine>(renderEngine), &keyboard};
+    glfwSetWindowUserPointer(renderEngine->window, &windowUser);
 
-	std::shared_ptr<IEAsset> fbx = std::make_shared<IEAsset>();
-	fbx->filename = "res/assets/AncientStatue/models/ancientStatue.fbx";
-	fbx->addAspect(new IERenderable{});
-	fbx->position = {2, 1, 0};
-	renderEngine->addAsset(fbx);
-	std::shared_ptr<IEAsset> obj = std::make_shared<IEAsset>();
-	obj->filename = "res/assets/AncientStatue/models/ancientStatue.obj";
-	obj->addAspect(new IERenderable{});
-	obj->position = {0, 1, 0};
-	renderEngine->addAsset(obj);
-	std::shared_ptr<IEAsset> glb = std::make_shared<IEAsset>();
-	glb->filename = "res/assets/AncientStatue/models/ancientStatue.glb";
-	glb->addAspect(new IERenderable{});
-	glb->position = {-2, 1, 0};
-	renderEngine->addAsset(glb);
-	std::shared_ptr<IEAsset> floor = std::make_shared<IEAsset>();
-	floor->filename = "res/assets/DeepslateFloor/models/DeepslateFloor.fbx";
-	floor->addAspect(new IERenderable{});
-	renderEngine->addAsset(floor);
-	floor->position = {0, 0, -1};
+    std::shared_ptr<IEAsset> fbx = std::make_shared<IEAsset>();
+    fbx->filename                = "res/assets/AncientStatue/models/ancientStatue.fbx";
+    fbx->addAspect(new IERenderable{});
+    fbx->position = {2, 1, 0};
+    renderEngine->addAsset(fbx);
+    std::shared_ptr<IEAsset> obj = std::make_shared<IEAsset>();
+    obj->filename                = "res/assets/AncientStatue/models/ancientStatue.obj";
+    obj->addAspect(new IERenderable{});
+    obj->position = {0, 1, 0};
+    renderEngine->addAsset(obj);
+    std::shared_ptr<IEAsset> glb = std::make_shared<IEAsset>();
+    glb->filename                = "res/assets/AncientStatue/models/ancientStatue.glb";
+    glb->addAspect(new IERenderable{});
+    glb->position = {-2, 1, 0};
+    renderEngine->addAsset(glb);
+    std::shared_ptr<IEAsset> floor = std::make_shared<IEAsset>();
+    floor->filename                = "res/assets/DeepslateFloor/models/DeepslateFloor.fbx";
+    floor->addAspect(new IERenderable{});
+    renderEngine->addAsset(floor);
+    floor->position = {0, 0, -1};
 
-	renderEngine->camera.position = {0.0F, -2.0F, 1.0F};
+    renderEngine->camera.position = {0.0F, -2.0F, 1.0F};
 
-	renderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, "Beginning main loop.");
+    renderEngine->settings->logger.log(ILLUMINATION_ENGINE_LOG_LEVEL_INFO, "Beginning main loop.");
 
-	glfwSetTime(0);
-	while (renderEngine->update()) {
-		glfwPollEvents();
-		keyboard.handleQueue();
-	}
+    glfwSetTime(0);
+    while (renderEngine->update()) {
+        glfwPollEvents();
+        keyboard.handleQueue();
+    }
 }


### PR DESCRIPTION
This pull request does two things. It fixes an error that was caused by the vkb::detail::Result<> struct being moved to vkb::Result<>. All usages have been replaced. Secondly, this pull request applys all the .clang-format formatting to all of the source files.